### PR TITLE
Rename SOL to XNT

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,46 +89,46 @@ mitigation to qualify.
 
 #### IMPORTANT | PLEASE NOTE
 _Beginning February 1st 2024, the Security bounty program payouts will be updated in the following ways:_
-- _Bug Bounty rewards will be denominated in SOL tokens, rather than USD value._
+- _Bug Bounty rewards will be denominated in XNT tokens, rather than USD value._
 _This change is to better reflect for changing value of the Solana network._
 - _Categories will now have a discretionary range to distinguish the varying severity_
 _and impact of bugs reported within each broader category._
 
-_Note: Payments will continue to be paid out in 12-month locked SOL._
+_Note: Payments will continue to be paid out in 12-month locked XNT._
 
 
 #### Loss of Funds:
-_Max: 25,000 SOL tokens. Min: 6,250 SOL tokens_
+_Max: 25,000 XNT tokens. Min: 6,250 XNT tokens_
 
 * Theft of funds without users signature from any account
 * Theft of funds without users interaction in system, stake, vote programs
 * Theft of funds that requires users signature - creating a vote program that drains the delegated stakes.
 
 #### Consensus/Safety Violations:
-_Max: 12,500 SOL tokens. Min: 3,125 SOL tokens_
+_Max: 12,500 XNT tokens. Min: 3,125 XNT tokens_
 
 * Consensus safety violation
 * Tricking a validator to accept an optimistic confirmation or rooted slot without a double vote, etc.
 
 #### Liveness / Loss of Availability:
-_Max: 5,000 SOL tokens. Min: 1,250 SOL tokens_
+_Max: 5,000 XNT tokens. Min: 1,250 XNT tokens_
 
 * Whereby consensus halts and requires human intervention
 * Eclipse attacks,
 * Remote attacks that partition the network,
 
 #### DoS Attacks:
-_Max: 1,250 SOL tokens. Min: 315 SOL tokens_
+_Max: 1,250 XNT tokens. Min: 315 XNT tokens_
 
 * Remote resource exhaustion via Non-RPC protocols
 
 #### Supply Chain Attacks:
-_Max: 1,250 SOL tokens. Min: 315 SOL tokens_
+_Max: 1,250 XNT tokens. Min: 315 XNT tokens_
 
 * Non-social attacks against source code change management, automated testing, release build, release publication and release hosting infrastructure of the monorepo.
 
 #### RPC DoS/Crashes:
-_Max: 65 SOL tokens. Min: 20 SOL tokens_
+_Max: 65 XNT tokens. Min: 20 XNT tokens_
 
 * RPC attacks
 
@@ -172,5 +172,5 @@ bi = 2 ^ (R - ri) / ((2^R) - 1)
 
 ### Payment of Bug Bounties:
 * Bounties are currently awarded on a rolling/weekly basis and paid out within 30 days upon receipt of an invoice.
-* Bug bounties that are paid out in SOL are paid to stake accounts with a lockup expiring 12 months from the date of delivery of SOL.
+* Bug bounties that are paid out in XNT are paid to stake accounts with a lockup expiring 12 months from the date of delivery of XNT.
 * **Note: payment notices need to be sent to ap@solana.org within 90 days of receiving payment advice instructions.** Failure to do so may result in forfeiture of the bug bounty reward.

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1576,7 +1576,7 @@ impl fmt::Display for CliStakeHistory {
                 if self.use_lamports_unit {
                     "lamports"
                 } else {
-                    "SOL"
+                    "XNT"
                 }
             )?;
         }
@@ -2025,7 +2025,7 @@ impl fmt::Display for CliAccountBalances {
                 f,
                 "{:<44}  {}",
                 account.address,
-                &format!("{} SOL", lamports_to_sol(account.lamports))
+                &format!("{} XNT", lamports_to_sol(account.lamports))
             )?;
         }
         Ok(())
@@ -2060,16 +2060,16 @@ impl VerboseDisplay for CliSupply {}
 
 impl fmt::Display for CliSupply {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln_name_value(f, "Total:", &format!("{} SOL", lamports_to_sol(self.total)))?;
+        writeln_name_value(f, "Total:", &format!("{} XNT", lamports_to_sol(self.total)))?;
         writeln_name_value(
             f,
             "Circulating:",
-            &format!("{} SOL", lamports_to_sol(self.circulating)),
+            &format!("{} XNT", lamports_to_sol(self.circulating)),
         )?;
         writeln_name_value(
             f,
             "Non-Circulating:",
-            &format!("{} SOL", lamports_to_sol(self.non_circulating)),
+            &format!("{} XNT", lamports_to_sol(self.non_circulating)),
         )?;
         if self.print_accounts {
             writeln!(f)?;
@@ -3528,12 +3528,12 @@ mod tests {
             ..CliVoteAccount::default()
         };
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\n  Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  1       100          1970-01-01 00:00:00 UTC  ◎0.000000010        ◎0.000000100               11.000%          10.00%          1%\n  2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.000000100               11.000%          13.00%          1%\n");
+        assert_eq!(s, "Account Balance: 0.00001 XNT\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\n  Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  1       100          1970-01-01 00:00:00 UTC  ◎0.000000010        ◎0.000000100               11.000%          10.00%          1%\n  2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.000000100               11.000%          13.00%          1%\n");
         println!("{s}");
 
         c.use_csv = true;
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n");
+        assert_eq!(s, "Account Balance: 0.00001 XNT\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n");
         println!("{s}");
     }
 }

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -68,7 +68,7 @@ pub fn build_balance_message_with_config(
             let ess = if lamports == 1 { "" } else { "s" };
             format!(" lamport{ess}")
         } else {
-            " SOL".to_string()
+            " XNT".to_string()
         }
     } else {
         "".to_string()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -488,11 +488,11 @@ pub enum CliError {
     ClientError(#[from] ClientError),
     #[error("Command not recognized: {0}")]
     CommandNotRecognized(String),
-    #[error("Account {1} has insufficient funds for fee ({0} SOL)")]
+    #[error("Account {1} has insufficient funds for fee ({0} XNT)")]
     InsufficientFundsForFee(f64, Pubkey),
-    #[error("Account {1} has insufficient funds for spend ({0} SOL)")]
+    #[error("Account {1} has insufficient funds for spend ({0} XNT)")]
     InsufficientFundsForSpend(f64, Pubkey),
-    #[error("Account {2} has insufficient funds for spend ({0} SOL) + fee ({1} SOL)")]
+    #[error("Account {2} has insufficient funds for spend ({0} XNT) + fee ({1} XNT)")]
     InsufficientFundsForSpendAndFee(f64, f64, Pubkey),
     #[error(transparent)]
     InvalidNonce(solana_rpc_client_nonce_utils::Error),
@@ -2102,7 +2102,7 @@ mod tests {
             pubkey: None,
             use_lamports_unit: false,
         };
-        assert_eq!(process_command(&config).unwrap(), "0.00000005 SOL");
+        assert_eq!(process_command(&config).unwrap(), "0.00000005 XNT");
 
         let good_signature = bs58::decode(SIGNATURE)
             .into_vec()
@@ -2461,7 +2461,7 @@ mod tests {
         write_keypair_file(&default_keypair, &default_keypair_file).unwrap();
         let default_signer = DefaultSigner::new("", &default_keypair_file);
 
-        // Test Transfer Subcommand, SOL
+        // Test Transfer Subcommand, XNT
         let from_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
         let from_pubkey = from_keypair.pubkey();
         let from_string = from_pubkey.to_string();

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -233,7 +233,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("supply")
-                .about("Get information about the cluster supply of SOL")
+                .about("Get information about the cluster supply of XNT")
                 .arg(
                     Arg::with_name("print_accounts")
                         .long("print-accounts")
@@ -243,7 +243,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("total-supply")
-                .about("Get total number of SOL")
+                .about("Get total number of XNT")
                 .setting(AppSettings::Hidden),
         )
         .subcommand(
@@ -345,7 +345,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 )
                 .arg(pubkey!(
                     Arg::with_name("vote_account_pubkeys")
@@ -370,7 +370,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 )
                 .arg(
                     Arg::with_name("number")
@@ -505,7 +505,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display rent in lamports instead of SOL"),
+                        .help("Display rent in lamports instead of XNT"),
                 ),
         )
     }
@@ -1413,7 +1413,7 @@ pub fn process_supply(
 
 pub fn process_total_supply(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
     let supply = rpc_client.supply()?.value;
-    Ok(format!("{} SOL", lamports_to_sol(supply.total)))
+    Ok(format!("{} XNT", lamports_to_sol(supply.total)))
 }
 
 pub fn process_get_transaction_count(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -88,7 +88,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .required(true)
                         .validator(is_amount_or_all)
                         .help(
-                            "The amount to load the nonce account with, in SOL; accepts keyword \
+                            "The amount to load the nonce account with, in XNT; accepts keyword \
                              ALL",
                         ),
                 )
@@ -152,12 +152,12 @@ impl NonceSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 ),
         )
         .subcommand(
             SubCommand::with_name("withdraw-from-nonce-account")
-                .about("Withdraw SOL from the nonce account")
+                .about("Withdraw XNT from the nonce account")
                 .arg(pubkey!(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
@@ -170,7 +170,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "Recipient of withdrawn SOL."
+                    "Recipient of withdrawn XNT."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -179,7 +179,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)
-                        .help("The amount to withdraw from the nonce account, in SOL"),
+                        .help("The amount to withdraw from the nonce account, in XNT"),
                 )
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -259,7 +259,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(false)
                                 .help(
                                     "Use the designated program id even if the account already \
-                                     holds a large balance of SOL (Obsolete)",
+                                     holds a large balance of XNT (Obsolete)",
                                 ),
                         )
                         .arg(
@@ -540,7 +540,7 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("lamports")
                                 .long("lamports")
                                 .takes_value(false)
-                                .help("Display balance in lamports instead of SOL"),
+                                .help("Display balance in lamports instead of XNT"),
                         ),
                 )
                 .subcommand(
@@ -603,7 +603,7 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("lamports")
                                 .long("lamports")
                                 .takes_value(false)
-                                .help("Display balance in lamports instead of SOL"),
+                                .help("Display balance in lamports instead of XNT"),
                         )
                         .arg(
                             Arg::with_name("bypass_warning")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -157,7 +157,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_amount_or_all)
                         .required(true)
                         .help(
-                            "The amount to send to the stake account, in SOL; accepts keyword ALL",
+                            "The amount to send to the stake account, in XNT; accepts keyword ALL",
                         ),
                 )
                 .arg(pubkey!(
@@ -250,7 +250,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_amount_or_all)
                         .required(true)
                         .help(
-                            "The amount to send to the stake account, in SOL; accepts keyword ALL",
+                            "The amount to send to the stake account, in XNT; accepts keyword ALL",
                         ),
                 )
                 .arg(
@@ -489,7 +489,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
-                        .help("The amount to move into the new stake account, in SOL"),
+                        .help("The amount to move into the new stake account, in XNT"),
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -516,7 +516,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .requires("sign_only")
                         .help(
                             "Offline signing only: the rent-exempt amount to move into the new \
-                             stake account, in SOL",
+                             stake account, in XNT",
                         ),
                 ),
         )
@@ -547,7 +547,7 @@ impl StakeSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("withdraw-stake")
-                .about("Withdraw the unstaked SOL from the stake account")
+                .about("Withdraw the unstaked XNT from the stake account")
                 .arg(pubkey!(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
@@ -571,7 +571,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_amount_or_all)
                         .required(true)
                         .help(
-                            "The amount to withdraw from the stake account, in SOL; accepts \
+                            "The amount to withdraw from the stake account, in XNT; accepts \
                              keyword ALL",
                         ),
                 )
@@ -724,7 +724,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 )
                 .arg(
                     Arg::with_name("with_rewards")
@@ -768,7 +768,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 )
                 .arg(
                     Arg::with_name("limit")
@@ -790,7 +790,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display minimum delegation in lamports instead of SOL"),
+                        .help("Display minimum delegation in lamports instead of XNT"),
                 ),
         )
     }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -340,7 +340,7 @@ impl VoteSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 )
                 .arg(
                     Arg::with_name("with_rewards")
@@ -391,7 +391,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The recipient of withdrawn SOL."
+                    "The recipient of withdrawn XNT."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -401,7 +401,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .required(true)
                         .validator(is_amount_or_all)
                         .help(
-                            "The amount to withdraw, in SOL; accepts keyword ALL, which for this \
+                            "The amount to withdraw, in XNT; accepts keyword ALL, which for this \
                              command means account balance minus rent-exempt minimum",
                         ),
                 )
@@ -434,7 +434,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The recipient of all withdrawn SOL."
+                    "The recipient of all withdrawn XNT."
                 ))
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -1434,7 +1434,7 @@ pub fn process_withdraw_from_vote_account(
             let balance_remaining = current_balance.saturating_sub(withdraw_amount);
             if balance_remaining < minimum_balance && balance_remaining != 0 {
                 return Err(CliError::BadParameter(format!(
-                    "Withdraw amount too large. The vote account balance must be at least {} SOL \
+                    "Withdraw amount too large. The vote account balance must be at least {} XNT \
                      to remain rent exempt",
                     lamports_to_sol(minimum_balance)
                 ))

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -76,7 +76,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 ),
         )
         .subcommand(
@@ -91,7 +91,7 @@ impl WalletSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("airdrop")
-                .about("Request SOL from a faucet")
+                .about("Request XNT from a faucet")
                 .arg(
                     Arg::with_name("amount")
                         .index(1)
@@ -99,7 +99,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
-                        .help("The airdrop amount to request, in SOL"),
+                        .help("The airdrop amount to request, in XNT"),
                 )
                 .arg(pubkey!(
                     Arg::with_name("to")
@@ -121,7 +121,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                        .help("Display balance in lamports instead of XNT"),
                 ),
         )
         .subcommand(
@@ -271,7 +271,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to send, in SOL; accepts keyword ALL"),
+                        .help("The amount to send, in XNT; accepts keyword ALL"),
                 )
                 .arg(pubkey!(
                     Arg::with_name("from")

--- a/cli/tests/address_lookup_table.rs
+++ b/cli/tests/address_lookup_table.rs
@@ -32,7 +32,7 @@ fn test_cli_create_extend_and_freeze_address_lookup_table() {
     config.signers = vec![&keypair];
     config.output_format = OutputFormat::JsonCompact;
 
-    // Airdrop SOL for transaction fees
+    // Airdrop XNT for transaction fees
     config.command = CliCommand::Airdrop {
         pubkey: None,
         lamports: 10 * LAMPORTS_PER_SOL,
@@ -146,7 +146,7 @@ fn test_cli_create_and_deactivate_address_lookup_table() {
     config.signers = vec![&keypair];
     config.output_format = OutputFormat::JsonCompact;
 
-    // Airdrop SOL for transaction fees
+    // Airdrop XNT for transaction fees
     config.command = CliCommand::Airdrop {
         pubkey: None,
         lamports: 10 * LAMPORTS_PER_SOL,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -253,7 +253,7 @@ fn test_cli_program_deploy_non_upgradeable() {
     });
     expect_command_failure(
         &config,
-        "The CLI blocks deployments into accounts that hold more than the necessary amount of SOL",
+        "The CLI blocks deployments into accounts that hold more than the necessary amount of XNT",
         &format!(
             "Account {} is not an upgradeable program or already in use",
             custom_address_keypair.pubkey()

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -73,7 +73,7 @@ fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
         .max(1);
     check_balance!(expected_balance, &rpc_client, &vote_account_pubkey);
 
-    // Transfer in some more SOL
+    // Transfer in some more XNT
     config.signers = vec![&default_signer];
     config.command = CliCommand::Transfer {
         amount: SpendAmount::Some(10_000),
@@ -301,7 +301,7 @@ fn test_offline_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
         .max(1);
     check_balance!(expected_balance, &rpc_client, &vote_account_pubkey);
 
-    // Transfer in some more SOL
+    // Transfer in some more XNT
     config_payer.signers = vec![&default_signer];
     config_payer.command = CliCommand::Transfer {
         amount: SpendAmount::Some(10_000),

--- a/docs/src/cli/.usage.md.header
+++ b/docs/src/cli/.usage.md.header
@@ -19,14 +19,14 @@ $ solana-keygen pubkey
 <PUBKEY>
 ```
 
-### Airdrop SOL/Lamports
+### Airdrop XNT/Lamports
 
 ```bash
 // Command
 $ solana airdrop 1
 
 // Return
-"1 SOL"
+"1 XNT"
 ```
 
 ### Get Balance
@@ -36,7 +36,7 @@ $ solana airdrop 1
 $ solana balance
 
 // Return
-"3.00050001 SOL"
+"3.00050001 XNT"
 ```
 
 ### Confirm Transaction

--- a/docs/src/cli/examples/delegate-stake.md
+++ b/docs/src/cli/examples/delegate-stake.md
@@ -1,14 +1,14 @@
 ---
-title: Staking SOL with the Solana CLI
+title: Staking XNT with the Solana CLI
 pagination_label: "Solana CLI: Staking"
 sidebar_label: Staking
 ---
 
-After you have [received SOL](./transfer-tokens.md), you might consider putting it
+After you have [received XNT](./transfer-tokens.md), you might consider putting it
 to use by delegating _stake_ to a validator. Stake is what we call tokens in a
 _stake account_. Solana weights validator votes by the amount of stake delegated
 to them, which gives those validators more influence in determining the next
-valid block of transactions in the blockchain. Solana then generates new SOL
+valid block of transactions in the blockchain. Solana then generates new XNT
 periodically to reward stakers and validators. You earn more rewards the more
 stake you delegate.
 
@@ -63,7 +63,7 @@ solana stake-account <STAKE_ACCOUNT_ADDRESS>
 The output will look similar to this:
 
 ```text
-Total Stake: 5000 SOL
+Total Stake: 5000 XNT
 Stake account is undelegated
 Stake Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F
 Withdraw Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F
@@ -149,9 +149,9 @@ You will see new fields "Delegated Stake" and "Delegated Vote Account Address"
 in the output. The output will look similar to this:
 
 ```text
-Total Stake: 5000 SOL
+Total Stake: 5000 XNT
 Credits Observed: 147462
-Delegated Stake: 4999.99771712 SOL
+Delegated Stake: 4999.99771712 XNT
 Delegated Vote Account Address: CcaHc2L43ZWjwCHART3oZoJvHLAe9hzT2DJNUpBzoTN1
 Stake activates starting from epoch: 42
 Stake Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F

--- a/docs/src/cli/examples/durable-nonce.md
+++ b/docs/src/cli/examples/durable-nonce.md
@@ -111,8 +111,8 @@ solana nonce-account nonce-keypair.json
 - Output
 
 ```text
-balance: 0.5 SOL
-minimum balance required: 0.00136416 SOL
+balance: 0.5 XNT
+minimum balance required: 0.00136416 XNT
 nonce: DZar6t2EaCFQTbUP4DHKwZ1wT8gCPW2aRfkVWhydkBvS
 ```
 
@@ -172,7 +172,7 @@ The following subcommands have received this treatment so far
 
 ### Example Pay Using Durable Nonce
 
-Here we demonstrate Alice paying Bob 1 SOL using a durable nonce. The procedure
+Here we demonstrate Alice paying Bob 1 XNT using a durable nonce. The procedure
 is the same for all subcommands supporting durable nonces
 
 #### - Create accounts
@@ -188,11 +188,11 @@ $ solana-keygen new -o bob.json
 #### - Fund Alice's account
 
 Alice will need some funds to create a nonce account and send to Bob. Airdrop
-her some SOL
+her some XNT
 
 ```bash
 $ solana airdrop -k alice.json 1
-1 SOL
+1 XNT
 ```
 
 #### - Create Alice's nonce account
@@ -228,8 +228,8 @@ blockhash stored there
 
 ```bash
 $ solana nonce-account nonce.json
-balance: 0.1 SOL
-minimum balance required: 0.00136416 SOL
+balance: 0.1 XNT
+minimum balance required: 0.00136416 XNT
 nonce: F7vmkY3DTaxfagttWjQweib42b6ZHADSx94Tw8gHx3W7
 ```
 
@@ -240,17 +240,17 @@ HR1368UKHVZyenmH7yVz5sBAijV6XAPeWbEiXEGVYQorRMcoijeNAbzZqEZiH8cDB8tk65ckqeegFjK8
 
 #### - Success!
 
-The transaction succeeds! Bob receives 0.01 SOL from Alice and Alice's stored
+The transaction succeeds! Bob receives 0.01 XNT from Alice and Alice's stored
 nonce advances to a new value
 
 ```bash
 $ solana balance -k bob.json
-0.01 SOL
+0.01 XNT
 ```
 
 ```bash
 $ solana nonce-account nonce.json
-balance: 0.1 SOL
-minimum balance required: 0.00136416 SOL
+balance: 0.1 XNT
+minimum balance required: 0.00136416 XNT
 nonce: 6bjroqDcZgTv6Vavhqf81oBHTv3aMnX19UTB51YhAZnN
 ```

--- a/docs/src/cli/examples/test-validator.md
+++ b/docs/src/cli/examples/test-validator.md
@@ -88,7 +88,7 @@ solana balance
 
 - **NOTE:** `Error: No such file or directory (os error 2)` means that the default
   wallet does not yet exist. Create it with `solana-keygen new`.
-- **NOTE:** If the wallet has a zero SOL balance, airdrop some localnet SOL with
+- **NOTE:** If the wallet has a zero XNT balance, airdrop some localnet XNT with
   `solana airdrop 10`
 
 #### Perform a basic transfer transaction

--- a/docs/src/cli/examples/transfer-tokens.md
+++ b/docs/src/cli/examples/transfer-tokens.md
@@ -4,7 +4,7 @@ pagination_label: "Solana CLI: Send and Receive Tokens"
 sidebar_label: Send and Receive Tokens
 ---
 
-This page describes how to receive and send SOL tokens using the command line
+This page describes how to receive and send XNT tokens using the command line
 tools with a command line wallet such as a [paper wallet](../wallets/paper.md),
 a [file system wallet](../wallets/file-system.md), or a
 [hardware wallet](../wallets/hardware/index.md). Before you begin, make sure
@@ -46,7 +46,7 @@ solana confirm -v <TRANSACTION_SIGNATURE>
 #### Check your balance
 
 Confirm the airdrop was successful by checking the account's balance.
-It should output `1 SOL`:
+It should output `1 XNT`:
 
 ```bash
 solana balance <ACCOUNT_ADDRESS> --url https://api.devnet.solana.com
@@ -111,12 +111,12 @@ Save this seed phrase to recover your new keypair:
 width enhance concert vacant ketchup eternal spy craft spy guard tag punch    # If this was a real wallet, never share these words on the internet like this!
 ==========================================================================
 
-$ solana airdrop 1 DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK --url https://api.devnet.solana.com  # Airdropping 1 SOL to my wallet's address/pubkey
-Requesting airdrop of 1 SOL from 35.233.193.70:9900
-1 SOL
+$ solana airdrop 1 DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK --url https://api.devnet.solana.com  # Airdropping 1 XNT to my wallet's address/pubkey
+Requesting airdrop of 1 XNT from 35.233.193.70:9900
+1 XNT
 
 $ solana balance DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK --url https://api.devnet.solana.com # Check the address's balance
-1 SOL
+1 XNT
 
 $ solana-keygen new --no-outfile  # Creating a second wallet, a paper wallet
 Generating a new keypair
@@ -132,10 +132,10 @@ $ solana transfer --from my_solana_wallet.json 7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBM
 3gmXvykAd1nCQQ7MjosaHLf69Xyaqyq1qw2eu1mgPyYXd5G4v1rihhg1CiRw35b9fHzcftGKKEu4mbUeXY2pEX2z  # This is the transaction signature
 
 $ solana balance DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK --url https://api.devnet.solana.com
-0.499995 SOL  # The sending account has slightly less than 0.5 SOL remaining due to the 0.000005 SOL transaction fee payment
+0.499995 XNT  # The sending account has slightly less than 0.5 XNT remaining due to the 0.000005 XNT transaction fee payment
 
 $ solana balance 7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv --url https://api.devnet.solana.com
-0.5 SOL  # The second wallet has now received the 0.5 SOL transfer from the first wallet
+0.5 XNT  # The second wallet has now received the 0.5 XNT transfer from the first wallet
 
 ```
 
@@ -152,7 +152,7 @@ characters. Its length varies from 32 to 44 characters.
 
 ## Send Tokens
 
-If you already hold SOL and want to send tokens to someone, you will need
+If you already hold XNT and want to send tokens to someone, you will need
 a path to your keypair, their base58-encoded public key, and a number of
 tokens to transfer. Once you have that collected, you can transfer tokens
 with the `solana transfer` command:

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -6,7 +6,7 @@ pagination_label: Solana CLI Tool Suite
 ---
 
 In this section, we will describe how to use the Solana command-line tools to
-create a _wallet_, to send and receive SOL tokens, and to participate in the
+create a _wallet_, to send and receive XNT tokens, and to participate in the
 cluster by delegating stake.
 
 To interact with a Solana cluster, we will use its command-line interface, also

--- a/docs/src/cli/wallets/file-system.md
+++ b/docs/src/cli/wallets/file-system.md
@@ -9,7 +9,7 @@ This document describes how to create and use a file system wallet with the
 Solana CLI tools. A file system wallet exists as an unencrypted keypair file
 on your computer system's filesystem.
 
-> File system wallets are the **least secure** method of storing SOL tokens. Storing large amounts of tokens in a file system wallet is **not recommended**.
+> File system wallets are the **least secure** method of storing XNT tokens. Storing large amounts of tokens in a file system wallet is **not recommended**.
 
 ## Before you Begin
 

--- a/docs/src/cli/wallets/hardware/ledger.md
+++ b/docs/src/cli/wallets/hardware/ledger.md
@@ -97,12 +97,12 @@ You can also view the balance of any account address on the Accounts tab in the
 [Explorer](https://explorer.solana.com/accounts) and paste the address in the
 box to view the balance in your web browser.
 
-Note: Any address with a balance of 0 SOL, such as a newly created one on your
+Note: Any address with a balance of 0 XNT, such as a newly created one on your
 Ledger, will show as "Not Found" in the explorer. Empty accounts and
 non-existent accounts are treated the same in Solana. This will change when your
-account address has some SOL in it.
+account address has some XNT in it.
 
-### Send SOL from a Nano
+### Send XNT from a Nano
 
 To send some tokens from an address controlled by your Nano, you will need to
 use the device to sign a transaction, using the same keypair URL you used to
@@ -121,7 +121,7 @@ solana transfer RECIPIENT_ADDRESS AMOUNT --keypair KEYPAIR_URL_OF_SENDER
 
 Below is a full example. First, an address is viewed at a certain keypair URL.
 Second, the balance of that address is checked. Lastly, a transfer transaction
-is entered to send `1` SOL to the recipient address
+is entered to send `1` XNT to the recipient address
 `7cvkjYAkUYs4W8XcXsca7cBrEGFeSUjeZmKoNBvEwyri`. When you hit Enter for a
 transfer command, you will be prompted to approve the transaction details on
 your Ledger device. On the device, use the right and left buttons to review the
@@ -133,7 +133,7 @@ screen, otherwise push both buttons on the "Reject" screen.
 CjeqzArkZt6xwdnZ9NZSf8D1CNJN1rjeFiyd8q7iLWAV
 
 ~$ solana balance CjeqzArkZt6xwdnZ9NZSf8D1CNJN1rjeFiyd8q7iLWAV
-1.000005 SOL
+1.000005 XNT
 
 ~$ solana transfer 7cvkjYAkUYs4W8XcXsca7cBrEGFeSUjeZmKoNBvEwyri 1 --keypair usb://ledger?key=42
 Waiting for your approval on Ledger hardware wallet usb://ledger/2JT2Xvy6T8hSmT8g6WdeDbHUgoeGdj6bE2VueCZUJmyN

--- a/docs/src/clusters/available.md
+++ b/docs/src/clusters/available.md
@@ -129,7 +129,7 @@ The identities of the
 
 A permissionless, persistent cluster for Solana users, builders, validators and token holders.
 
-- Tokens that are issued on Mainnet Beta are **real** SOL
+- Tokens that are issued on Mainnet Beta are **real** XNT
 - Gossip entrypoint for Mainnet Beta: `entrypoint.mainnet-beta.solana.com:8001`
 - Metrics environment variable for Mainnet Beta:
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -33,7 +33,7 @@ Anyone can operate a validator.  All Solana clusters are permissionless. A new o
 
 ### Is there a validator set or limited number of validators that can operate?
 
-No, all Solana clusters are permissionless.  There is no limit to the number of active validators that can participate in consensus.  Validators participating in consensus (voting validators) incur transaction fees for each vote.  A voting validator can expect to incur up to 1.1 SOL per day in vote transaction fees.
+No, all Solana clusters are permissionless.  There is no limit to the number of active validators that can participate in consensus.  Validators participating in consensus (voting validators) incur transaction fees for each vote.  A voting validator can expect to incur up to 1.1 XNT per day in vote transaction fees.
 
 ### What are the hardware requirements for running a validator?
 

--- a/docs/src/implemented-proposals/ed_overview/ed_validation_client_economics/ed_vce_state_validation_protocol_based_rewards.md
+++ b/docs/src/implemented-proposals/ed_overview/ed_validation_client_economics/ed_vce_state_validation_protocol_based_rewards.md
@@ -37,10 +37,10 @@ From these simulated _Inflation Schedules_, we can also project ranges for token
 
 ![](/img/p_total_supply_ranges.png)
 
-Finally we can estimate the _Staked Yield_ on staked SOL, if we introduce an additional parameter, previously discussed, _% of Staked SOL_:
+Finally we can estimate the _Staked Yield_ on staked XNT, if we introduce an additional parameter, previously discussed, _% of Staked SOL_:
 
 $$
-\%~\text{SOL Staked} = \frac{\text{Total SOL Staked}}{\text{Total Current Supply}}
+\%~\text{XNT Staked} = \frac{\text{Total XNT Staked}}{\text{Total Current Supply}}
 $$
 
 In this case, because _% of Staked SOL_ is a parameter that must be estimated (unlike the _Inflation Schedule_ parameters), it is easier to use specific _Inflation Schedule_ parameters and explore a range of _% of Staked SOL_. For the below example, we’ve chosen the middle of the parameter ranges explored above:

--- a/docs/src/implemented-proposals/staking-rewards.md
+++ b/docs/src/implemented-proposals/staking-rewards.md
@@ -2,7 +2,7 @@
 title: Staking Rewards
 ---
 
-A Proof of Stake \(PoS\), \(i.e. using in-protocol asset, SOL, to provide secure consensus\) design is outlined here. Solana implements a proof of stake reward/security scheme for validator nodes in the cluster. The purpose is threefold:
+A Proof of Stake \(PoS\), \(i.e. using in-protocol asset, XNT, to provide secure consensus\) design is outlined here. Solana implements a proof of stake reward/security scheme for validator nodes in the cluster. The purpose is threefold:
 
 - Align validator incentives with that of the greater cluster through skin-in-the-game deposits at risk
 
@@ -16,15 +16,15 @@ While many of the details of the specific implementation are currently under con
 
 Solana's ledger validation design is based on a rotating, stake-weighted selected leader broadcasting transactions in a PoH data structure to validating nodes. These nodes, upon receiving the leader's broadcast, have the opportunity to vote on the current state and PoH height by signing a transaction into the PoH stream.
 
-To become a Solana validator, one must deposit/lock-up some amount of SOL in a contract. This SOL will not be accessible for a specific time period. The precise duration of the staking lockup period has not been determined. However we can consider three phases of this time for which specific parameters will be necessary:
+To become a Solana validator, one must deposit/lock-up some amount of XNT in a contract. This XNT will not be accessible for a specific time period. The precise duration of the staking lockup period has not been determined. However we can consider three phases of this time for which specific parameters will be necessary:
 
-- _Warm-up period_: which SOL is deposited and inaccessible to the node, however PoH transaction validation has not begun. Most likely on the order of days to weeks
+- _Warm-up period_: which XNT is deposited and inaccessible to the node, however PoH transaction validation has not begun. Most likely on the order of days to weeks
 
-- _Validation period_: a minimum duration for which the deposited SOL will be inaccessible, at risk of slashing \(see slashing rules below\) and earning rewards for the validator participation. Likely duration of months to a year.
+- _Validation period_: a minimum duration for which the deposited XNT will be inaccessible, at risk of slashing \(see slashing rules below\) and earning rewards for the validator participation. Likely duration of months to a year.
 
 - _Cool-down period_: a duration of time following the submission of a 'withdrawal' transaction. During this period validation responsibilities have been removed and the funds continue to be inaccessible. Accumulated rewards should be delivered at the end of this period, along with the return of the initial deposit.
 
-Solana's trustless sense of time and ordering provided by its PoH data structure, along with its [turbine](https://docs.anza.xyz/consensus/turbine-block-propagation) data broadcast and transmission design, should provide sub-second transaction confirmation times that scale with the log of the number of nodes in the cluster. This means we shouldn't have to restrict the number of validating nodes with a prohibitive 'minimum deposits' and expect nodes to be able to become validators with nominal amounts of SOL staked. At the same time, Solana's focus on high-throughput should create incentive for validation clients to provide high-performant and reliable hardware. Combined with potentially a minimum network speed threshold to join as a validation-client, we expect a healthy validation delegation market to emerge.
+Solana's trustless sense of time and ordering provided by its PoH data structure, along with its [turbine](https://docs.anza.xyz/consensus/turbine-block-propagation) data broadcast and transmission design, should provide sub-second transaction confirmation times that scale with the log of the number of nodes in the cluster. This means we shouldn't have to restrict the number of validating nodes with a prohibitive 'minimum deposits' and expect nodes to be able to become validators with nominal amounts of XNT staked. At the same time, Solana's focus on high-throughput should create incentive for validation clients to provide high-performant and reliable hardware. Combined with potentially a minimum network speed threshold to join as a validation-client, we expect a healthy validation delegation market to emerge.
 
 ## Penalties
 

--- a/docs/src/index.mdx
+++ b/docs/src/index.mdx
@@ -50,7 +50,7 @@ Explore what it takes to operate an Tachyon validator and help secure the networ
   the important differences between voting and non-voting validators on the
   network
 - [System requirements](./operations/requirements.md) - Recommended hardware
-  requirements and expected SOL needed to operate a validator
+  requirements and expected XNT needed to operate a validator
 - [Quick start guide](./operations/setup-a-validator.md) - Setup a validator and
   get connected to a cluster for the first time
 

--- a/docs/src/operations/best-practices/general.md
+++ b/docs/src/operations/best-practices/general.md
@@ -199,7 +199,7 @@ It is important that you do not accidentally run out of funds in your identity
 account, as your node will stop voting. It is also important to note that this
 account keypair is the most vulnerable of the three keypairs in a vote account
 because the keypair for the identity account is stored on your validator when
-running the `tachyon-validator` software. How much SOL you should store there is
+running the `tachyon-validator` software. How much XNT you should store there is
 up to you. As a best practice, make sure to check the account regularly and
 refill or deduct from it as needed. To check the account balance do:
 

--- a/docs/src/operations/guides/validator-stake.md
+++ b/docs/src/operations/guides/validator-stake.md
@@ -37,7 +37,7 @@ solana-keygen new -o ~/validator-stake-keypair.json
 
 ## Delegate Stake
 
-Now delegate 1 SOL to your validator by first creating your stake account:
+Now delegate 1 XNT to your validator by first creating your stake account:
 
 ```bash
 solana create-stake-account ~/validator-stake-keypair.json 1
@@ -49,7 +49,7 @@ and then delegating that stake to your validator:
 solana delegate-stake ~/validator-stake-keypair.json ~/vote-account-keypair.json
 ```
 
-> Don’t delegate your remaining SOL, as your validator will use those tokens to
+> Don’t delegate your remaining XNT, as your validator will use those tokens to
 > vote.
 
 Stakes can be re-delegated to another node at any time with the same command,

--- a/docs/src/operations/guides/validator-start.md
+++ b/docs/src/operations/guides/validator-start.md
@@ -169,7 +169,7 @@ network. **It is crucial to back-up this information.**
 
 If you don’t back up this information, you WILL NOT BE ABLE TO RECOVER YOUR
 VALIDATOR if you lose access to it. If this happens, YOU WILL LOSE YOUR
-ALLOCATION OF SOL TOO.
+ALLOCATION OF XNT TOO.
 
 To back-up your validator identify keypair, **back-up your
 "validator-keypair.json” file or your seed phrase to a secure location.**
@@ -195,14 +195,14 @@ Commitment: confirmed
 
 ## Airdrop & Check Validator Balance
 
-Airdrop yourself some SOL to get started:
+Airdrop yourself some XNT to get started:
 
 ```bash
 solana airdrop 1
 ```
 
 Note that airdrops are only available on Devnet and Testnet. Both are limited
-to 1 SOL per request.
+to 1 XNT per request.
 
 To view your current balance:
 
@@ -216,7 +216,7 @@ Or to see in finer detail:
 solana balance --lamports
 ```
 
-Read more about the [difference between SOL and lamports here](https://solana.com/docs/intro#what-are-sols).
+Read more about the [difference between XNT and lamports here](https://solana.com/docs/intro#what-are-sols).
 
 ## Create Authorized Withdrawer Account
 

--- a/docs/src/operations/guides/vote-accounts.md
+++ b/docs/src/operations/guides/vote-accounts.md
@@ -55,7 +55,7 @@ must be stored as a "hot wallet" in a keypair file on the same system the
 validator process is running.
 
 Because a hot wallet is generally less secure than an offline or "cold" wallet,
-the validator operator may choose to store only enough SOL on the identity
+the validator operator may choose to store only enough XNT on the identity
 account to cover voting fees for a limited amount of time, such as a few weeks
 or months. The validator identity account could be periodically topped off from
 a more secure wallet.
@@ -277,6 +277,6 @@ keypairs to the other even though both entities signed the transaction.
 
 A vote account can be closed with the
 [close-vote-account](../../cli/usage.md#solana-close-vote-account) command. Closing
-a vote account withdraws all remaining SOL funds to a supplied recipient address
+a vote account withdraws all remaining XNT funds to a supplied recipient address
 and renders it invalid as a vote account. It is not possible to close a vote
 account with active stake.

--- a/docs/src/operations/requirements.md
+++ b/docs/src/operations/requirements.md
@@ -5,14 +5,14 @@ sidebar_label: Requirements
 pagination_label: Requirements to Operate a Validator
 ---
 
-## Minimum SOL requirements
+## Minimum XNT requirements
 
-There is no strict minimum amount of SOL required to run an Agave validator on Solana.
+There is no strict minimum amount of XNT required to run an Agave validator on Solana.
 
 However in order to participate in consensus, a vote account is required which
-has a rent-exempt reserve of 0.02685864 SOL. Voting also requires sending a vote
+has a rent-exempt reserve of 0.02685864 XNT. Voting also requires sending a vote
 transaction for each block the validator agrees with, which can cost up to
-1.1 SOL per day.
+1.1 XNT per day.
 
 ## Hardware Recommendations
 

--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -119,7 +119,7 @@ Now verify your account balance of `0`:
 solana balance
 ```
 
-Next, you need to deposit some SOL into that keypair account in order create a
+Next, you need to deposit some XNT into that keypair account in order create a
 transaction (in this case, making your vote account):
 
 ```
@@ -127,7 +127,7 @@ solana airdrop 1
 ```
 
 > **NOTE** The `airdrop` sub command does not work on mainnet, so you will have
-> to acquire SOL and transfer it into this keypair's account if you are setting
+> to acquire XNT and transfer it into this keypair's account if you are setting
 > up a mainnet validator.
 
 Now, use the Solana cluster to create a vote account.
@@ -511,7 +511,7 @@ through the validator log output.
 ### Solana Validators
 
 After you have verified that your validator is in gossip, you should stake some
-SOL to your validator. Once the stake has activated (which happens at the start
+XNT to your validator. Once the stake has activated (which happens at the start
 of the next epoch), you can verify that your validator is ready to be a voting
 participant of the network with the `solana validators` command. The command
 lists all validators in the network, but like before, we can `grep` the output
@@ -524,7 +524,7 @@ solana validators | grep <pubkey>
 You should see a line of output that looks like this:
 
 ```
-5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on  FX6NNbS5GHc2kuzgTZetup6GZX6ReaWyki8Z8jC7rbNG  100%  197434166 (  0)  197434133 (  0)   2.11%   323614  1.14.17   2450110.588302720 SOL (1.74%)
+5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on  FX6NNbS5GHc2kuzgTZetup6GZX6ReaWyki8Z8jC7rbNG  100%  197434166 (  0)  197434133 (  0)   2.11%   323614  1.14.17   2450110.588302720 XNT (1.74%)
 ```
 
 ### Solana Catchup

--- a/docs/src/operations/validator-initiatives.md
+++ b/docs/src/operations/validator-initiatives.md
@@ -9,7 +9,7 @@ There are a number of initiatives that may help operators get started or grow th
 
 ## Solana Foundation Delegation Program
 
-The Solana Foundation helps facilitate the growth of the consensus validator network by running a SOL delegation program. The program is open to new applicants. You can find out more information [here](https://solana.org/delegation-program)
+The Solana Foundation helps facilitate the growth of the consensus validator network by running a XNT delegation program. The program is open to new applicants. You can find out more information [here](https://solana.org/delegation-program)
 
 ## Tour De Sun 22
 

--- a/docs/src/operations/validator-or-rpc-node.md
+++ b/docs/src/operations/validator-or-rpc-node.md
@@ -14,7 +14,7 @@ best for you based on your interests, technical background, and goals.
 
 As a validator your primary focus is maintaining the network and making sure
 that your node is performing optimally so that you can fully participate in the
-cluster consensus. You will want to attract a delegation of SOL to your
+cluster consensus. You will want to attract a delegation of XNT to your
 validator which will allow your validator the opportunity to produce more blocks
 and earn rewards.
 
@@ -31,9 +31,9 @@ produces that is added to the blockchain.
 
 Since all votes in Solana happen on the blockchain, a validator incurs a
 transaction cost for each vote that it makes. These transaction fees amount to
-approximately 1.0 SOL per day.
+approximately 1.0 XNT per day.
 
-> It is important to make sure your validator always has enough SOL in its
+> It is important to make sure your validator always has enough XNT in its
 > identity account to pay for these transactions!
 
 ### Economics of running a consensus validator
@@ -42,10 +42,10 @@ As an operator, it is important to understand how a consensus validator spends
 and earns sol through the protocol.
 
 All validators who vote (consensus validators) must pay vote transaction fees
-for blocks that they agree with. The cost of voting can be up to 1.1 SOL per
+for blocks that they agree with. The cost of voting can be up to 1.1 XNT per
 day.
 
-A voting validator can earn SOL through 2 methods:
+A voting validator can earn XNT through 2 methods:
 
 1. Inflationary rewards paid at the end of an epoch. See
    [staking rewards](../implemented-proposals/staking-rewards.md)

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -47,14 +47,14 @@ async fn main() {
                 .alias("cap")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Request limit for time slice, in SOL"),
+                .help("Request limit for time slice, in XNT"),
         )
         .arg(
             Arg::with_name("per_request_cap")
                 .long("per-request-cap")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Request limit for a single request, in SOL"),
+                .help("Request limit for a single request, in XNT"),
         )
         .arg(
             Arg::with_name("allowed_ip")

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -124,7 +124,7 @@ impl Faucet {
         if let Some((per_request_cap, per_time_cap)) = per_request_cap.zip(per_time_cap) {
             if per_time_cap < per_request_cap {
                 warn!(
-                    "per_time_cap {} SOL < per_request_cap {} SOL; \
+                    "per_time_cap {} XNT < per_request_cap {} XNT; \
                     maximum single requests will fail",
                     lamports_to_sol(per_time_cap),
                     lamports_to_sol(per_request_cap),
@@ -170,7 +170,7 @@ impl Faucet {
     /// Checks per-request and per-time-ip limits; if both pass, this method returns a signed
     /// SystemProgram::Transfer transaction from the faucet keypair to the requested recipient. If
     /// the request exceeds this per-request limit, this method returns a signed SPL Memo
-    /// transaction with the memo: `"request too large; req: <REQUEST> SOL cap: <CAP> SOL"`
+    /// transaction with the memo: `"request too large; req: <REQUEST> XNT cap: <CAP> XNT"`
     pub fn build_airdrop_transaction(
         &mut self,
         req: FaucetRequest,
@@ -185,7 +185,7 @@ impl Faucet {
             } => {
                 let mint_pubkey = self.faucet_keypair.pubkey();
                 info!(
-                    "Requesting airdrop of {} SOL to {:?}",
+                    "Requesting airdrop of {} XNT to {:?}",
                     lamports_to_sol(lamports),
                     to
                 );

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -285,7 +285,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                         slot_stake_and_vote_count.get(&bank.slot())
                     {
                         format!(
-                            "\nvotes: {}, stake: {:.1} SOL ({:.1}%)",
+                            "\nvotes: {}, stake: {:.1} XNT ({:.1}%)",
                             votes,
                             lamports_to_sol(*stake),
                             *stake as f64 / *total_stake as f64 * 100.,
@@ -382,7 +382,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
                     )
                 };
             dot.push(format!(
-                r#"  "last vote {}"[shape=box,label="Latest validator vote: {}\nstake: {} SOL\nroot slot: {}\n{}"];"#,
+                r#"  "last vote {}"[shape=box,label="Latest validator vote: {}\nstake: {} XNT\nroot slot: {}\n{}"];"#,
                 node_pubkey,
                 node_pubkey,
                 lamports_to_sol(*stake),
@@ -405,7 +405,7 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
     // Annotate the final "..." node with absent vote and stake information
     if absent_votes > 0 {
         dot.push(format!(
-            r#"    "..."[label="...\nvotes: {}, stake: {:.1} SOL {:.1}%"];"#,
+            r#"    "..."[label="...\nvotes: {}, stake: {:.1} XNT {:.1}%"];"#,
             absent_votes,
             lamports_to_sol(absent_stake),
             absent_stake as f64 / lowest_total_stake as f64 * 100.,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -943,7 +943,7 @@ pub fn output_account(
     encoding: UiAccountEncoding,
 ) {
     println!("{pubkey}:");
-    println!("  balance: {} SOL", lamports_to_sol(account.lamports()));
+    println!("  balance: {} XNT", lamports_to_sol(account.lamports()));
     println!("  owner: '{}'", account.owner());
     println!("  executable: {}", account.executable());
     if let Some(slot) = modified_slot {

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -8,7 +8,7 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-stake_sol=10   # default number of SOL to assign as stake (10 SOL)
+stake_sol=10   # default number of XNT to assign as stake (10 XNT)
 url=http://127.0.0.1:8899   # default RPC url
 
 usage() {
@@ -18,7 +18,7 @@ usage() {
   fi
   cat <<EOF
 
-usage: $0 [OPTIONS] <SOL to stake ($stake_sol)>
+usage: $0 [OPTIONS] <XNT to stake ($stake_sol)>
 
 Add stake to a validator
 

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -12,7 +12,7 @@ args=(
   --no-os-network-limits-test
 )
 airdrops_enabled=1
-node_sol=500 # 500 SOL: number of SOL to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)
+node_sol=500 # 500 XNT: number of XNT to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)
 label=
 identity=
 vote_account=
@@ -36,7 +36,7 @@ OPTIONS:
   --init-complete-file FILE - create this file, if it doesn't already exist, once node initialization is complete
   --label LABEL             - Append the given label to the configuration files, useful when running
                               multiple validators in the same workspace
-  --node-sol SOL            - Number of SOL this node has been funded from the genesis config (default: $node_sol)
+  --node-sol XNT            - Number of XNT this node has been funded from the genesis config (default: $node_sol)
   --no-voting               - start node without vote signer
   --rpc-port port           - custom RPC port for this node
   --no-restart              - do not restart the node if it exits

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -959,7 +959,7 @@ impl ProgramTest {
     /// Start the test client
     ///
     /// Returns a `BanksClient` interface into the test environment as well as a payer `Keypair`
-    /// with SOL for sending transactions
+    /// with XNT for sending transactions
     pub async fn start_with_context(mut self) -> ProgramTestContext {
         let (bank_forks, block_commitment_cache, last_blockhash, gci) = self.setup_bank();
         let target_tick_duration = gci.genesis_config.poh_config.target_tick_duration;

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -217,7 +217,7 @@ mod tests {
         let mut vote_state = VoteState::default();
 
         // bootstrap means fully-vested stake at epoch 0 with
-        //  10_000_000 SOL is a big but not unreasaonable stake
+        //  10_000_000 XNT is a big but not unreasaonable stake
         let stake = new_stake(
             sol_to_lamports(10_000_000f64),
             &Pubkey::default(),

--- a/programs/stake/src/rewards.rs
+++ b/programs/stake/src/rewards.rs
@@ -636,7 +636,7 @@ mod tests {
         let vote_state = VoteState::default();
 
         // bootstrap means fully-vested stake at epoch 0 with
-        //  10_000_000 SOL is a big but not unreasaonable stake
+        //  10_000_000 XNT is a big but not unreasaonable stake
         let stake = new_stake(
             sol_to_lamports(10_000_000f64),
             &Pubkey::default(),

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2234,7 +2234,7 @@ mod tests {
     fn test_dbg_stake_minimum_balance() {
         let minimum_balance = Rent::default().minimum_balance(StakeStateV2::size_of());
         panic!(
-            "stake minimum_balance: {} lamports, {} SOL",
+            "stake minimum_balance: {} lamports, {} XNT",
             minimum_balance,
             minimum_balance as f64 / solana_native_token::LAMPORTS_PER_SOL as f64
         );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8953,7 +8953,7 @@ pub mod tests {
 
         let sender = Keypair::new();
         let recipient = Keypair::new();
-        let transfer_amount = TEST_MINT_LAMPORTS / 100; // 0.01 SOL
+        let transfer_amount = TEST_MINT_LAMPORTS / 100; // 0.01 XNT
 
         let transfer_instruction =
             system_instruction::transfer(&sender.pubkey(), &recipient.pubkey(), transfer_amount);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9954,7 +9954,7 @@ fn test_get_largest_accounts() {
         ])
         .collect();
 
-    // Initialize accounts; all have larger SOL balances than current Bank built-ins
+    // Initialize accounts; all have larger XNT balances than current Bank built-ins
     let account0 = AccountSharedData::new(pubkeys_balances[0].1, 0, &Pubkey::default());
     bank.store_account(&pubkeys_balances[0].0, &account0);
     let account1 = AccountSharedData::new(pubkeys_balances[1].1, 0, &Pubkey::default());

--- a/stake-accounts/src/arg_parser.rs
+++ b/stake-accounts/src/arg_parser.rs
@@ -175,7 +175,7 @@ where
                         .takes_value(true)
                         .value_name("AMOUNT")
                         .validator(is_amount)
-                        .help("Amount to move into the new stake accounts, in SOL"),
+                        .help("Amount to move into the new stake accounts, in XNT"),
                 )
                 .arg(
                     Arg::with_name("stake_authority")

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -264,7 +264,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let balances = get_balances(&client, addresses)?;
             let lamports: u64 = balances.into_iter().map(|(_, bal)| bal).sum();
             let sol = lamports_to_sol(lamports);
-            println!("{sol} SOL");
+            println!("{sol} XNT");
         }
         Command::Authorize(args) => {
             process_authorize_stake_accounts(&client, &args)?;

--- a/svm/examples/paytube/README.md
+++ b/svm/examples/paytube/README.md
@@ -9,7 +9,7 @@ SVM-based solutions such as sidecars, channels, rollups, and more. This project
 demonstrates everything you need to know about bootstrapping with this new API.
 
 PayTube is a state channel (more specifically a payment channel), designed to
-allow multiple parties to transact amongst each other in SOL or SPL tokens
+allow multiple parties to transact amongst each other in XNT or SPL tokens
 off-chain. When the channel is closed, the resulting changes in each user's
 balances are posted to the base chain (Solana).
 

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -6,7 +6,7 @@
 //! channel is closed by submitting the final payment ledger to Solana.
 //!
 //! The final ledger tracks debits and credits to all registered token accounts
-//! or system accounts (native SOL) during the lifetime of a channel. It is
+//! or system accounts (native XNT) during the lifetime of a channel. It is
 //! then used to to craft a batch of transactions to submit to the settlement
 //! chain (Solana).
 //!
@@ -81,7 +81,7 @@ use {
 
 /// A PayTube channel instance.
 ///
-/// Facilitates native SOL or SPL token transfers amongst various channel
+/// Facilitates native XNT or SPL token transfers amongst various channel
 /// participants, settling the final changes in balances to the base chain.
 pub struct PayTubeChannel {
     /// I think you know why this is a bad idea...

--- a/svm/examples/paytube/src/settler.rs
+++ b/svm/examples/paytube/src/settler.rs
@@ -28,7 +28,7 @@ use {
 
 /// The key used for storing ledger entries.
 ///
-/// Each entry in the ledger represents the movement of SOL or tokens between
+/// Each entry in the ledger represents the movement of XNT or tokens between
 /// two parties. The two keys of the two parties are stored in a sorted array
 /// of length two, and the value's sign determines the direction of transfer.
 ///

--- a/svm/examples/paytube/src/transaction.rs
+++ b/svm/examples/paytube/src/transaction.rs
@@ -1,4 +1,4 @@
-//! PayTube's custom transaction format, tailored specifically for SOL or SPL
+//! PayTube's custom transaction format, tailored specifically for XNT or SPL
 //! token transfers.
 //!
 //! Mostly for demonstration purposes, to show how projects may use completely
@@ -19,10 +19,10 @@ use {
     std::collections::HashSet,
 };
 
-/// A simple PayTube transaction. Transfers SPL tokens or SOL from one account
+/// A simple PayTube transaction. Transfers SPL tokens or XNT from one account
 /// to another.
 ///
-/// A `None` value for `mint` represents native SOL.
+/// A `None` value for `mint` represents native XNT.
 pub struct PayTubeTransaction {
     pub mint: Option<Pubkey>,
     pub from: Pubkey,

--- a/system-test/genesis-test/cluster_token_count.sh
+++ b/system-test/genesis-test/cluster_token_count.sh
@@ -35,7 +35,7 @@ function get_token_capitalization {
   totalSupplySol=$((totalSupplyLamports / LAMPORTS_PER_SOL))
 
   printf "\n--- Token Capitalization ---\n"
-  printf "Total token capitalization %'d SOL\n" "$totalSupplySol"
+  printf "Total token capitalization %'d XNT\n" "$totalSupplySol"
   printf "Total token capitalization %'d Lamports\n" "$totalSupplyLamports"
 
 }
@@ -59,7 +59,7 @@ function get_program_account_balance_totals {
 
   printf "\n--- %s Account Balance Totals ---\n" "$PROGRAM_NAME"
   printf "Number of %s Program accounts: %'.f\n" "$PROGRAM_NAME" "$numberOfAccounts"
-  printf "Total token balance in all %s accounts: %'d SOL\n" "$PROGRAM_NAME" "$totalAccountBalancesSol"
+  printf "Total token balance in all %s accounts: %'d XNT\n" "$PROGRAM_NAME" "$totalAccountBalancesSol"
   printf "Total token balance in all %s accounts: %'d Lamports\n" "$PROGRAM_NAME" "$totalAccountBalancesLamports"
 
   case $PROGRAM_NAME in
@@ -91,7 +91,7 @@ function sum_account_balances_totals {
   grandTotalAccountBalancesLamports=$((systemAccountBalanceTotalLamports + stakeAccountBalanceTotalLamports + voteAccountBalanceTotalLamports + configAccountBalanceTotalLamports))
 
   printf "\n--- Total Token Distribution in all Account Balances ---\n"
-  printf "Total SOL in all Account Balances: %'d\n" "$grandTotalAccountBalancesSol"
+  printf "Total XNT in all Account Balances: %'d\n" "$grandTotalAccountBalancesSol"
   printf "Total Lamports in all Account Balances: %'d\n" "$grandTotalAccountBalancesLamports"
 }
 

--- a/system-test/genesis-test/get_owned_accounts_info.sh
+++ b/system-test/genesis-test/get_owned_accounts_info.sh
@@ -72,13 +72,13 @@ function display_results_summary {
   echo ""
   printf "Number of STAKE accounts: %'d\n" "$num_stake_accounts"
   printf "Balance of all STAKE accounts: %'d lamports\n" "$stake_account_balance_total"
-  printf "Balance of all STAKE accounts: %'.3f SOL\n" "$stake_account_balance_total_sol"
+  printf "Balance of all STAKE accounts: %'.3f XNT\n" "$stake_account_balance_total_sol"
   printf "\n"
   printf "Balance of SYSTEM account: %'d lamports\n" "$system_account_balance"
-  printf "Balance of SYSTEM account: %'.3f SOL\n" "$system_account_balance_sol"
+  printf "Balance of SYSTEM account: %'.3f XNT\n" "$system_account_balance_sol"
   printf "\n"
   printf "Total Balance of ALL accounts: %'d lamports\n" "$all_account_total_balance"
-  printf "Total Balance of ALL accounts: %'.3f SOL\n" "$all_account_total_balance_sol"
+  printf "Total Balance of ALL accounts: %'.3f XNT\n" "$all_account_total_balance_sol"
   echo "--------------------------------------------------------------------------------------"
 }
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -120,15 +120,15 @@ solana-tokens distribute-stake --stake-account-address <ACCOUNT_ADDRESS> \
     --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> --fee-payer <KEYPAIR>
 ```
 
-Currently, this will subtract 1 SOL from each allocation and store it in the
-recipient address. That SOL can be used to pay transaction fees on staking
+Currently, this will subtract 1 XNT from each allocation and store it in the
+recipient address. That XNT can be used to pay transaction fees on staking
 operations such as delegating stake. The rest of the allocation is put in
 a stake account. The new stake account address is output in the transaction
 log.
 
 ## Distribute SPL tokens
 
-Distributing SPL Tokens works very similarly to distributing SOL, but requires
+Distributing SPL Tokens works very similarly to distributing XNT, but requires
 the `--owner` parameter to sign transactions. Each recipient account must be an
 system account that will own an Associated Token Account for the SPL Token mint.
 The Associated Token Account will be created, and funded by the fee_payer, if it
@@ -188,7 +188,7 @@ C56nwrDVFpPrqwGYsTgQxv1ZraTh81H14PV4RHvZe36s                    10.000
 
 ### Calculate what tokens should be sent
 
-As with SOL, you can List the differences between a list of expected
+As with XNT, you can List the differences between a list of expected
 distributions and the record of what transactions have already been sent using
 the `--dry-run` parameter, or `solana-tokens balances`.
 

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -50,7 +50,7 @@ where
         )
         .subcommand(
             SubCommand::with_name("distribute-tokens")
-                .about("Distribute SOL")
+                .about("Distribute XNT")
                 .arg(
                     Arg::with_name("db_path")
                         .long("db-path")
@@ -77,7 +77,7 @@ where
                         .takes_value(true)
                         .value_name("AMOUNT")
                         .validator(is_amount)
-                        .help("The amount to send to each recipient, in SOL"),
+                        .help("The amount to send to each recipient, in XNT"),
                 )
                 .arg(
                     Arg::with_name("dry_run")
@@ -162,7 +162,7 @@ where
                         .long("unlocked-sol")
                         .takes_value(true)
                         .value_name("SOL_AMOUNT")
-                        .help("Amount of SOL to put in system account to pay for fees"),
+                        .help("Amount of XNT to put in system account to pay for fees"),
                 )
                 .arg(
                     Arg::with_name("lockup_authority")
@@ -242,7 +242,7 @@ where
                         .long("unlocked-sol")
                         .takes_value(true)
                         .value_name("SOL_AMOUNT")
-                        .help("Amount of SOL to put in system account to pay for fees"),
+                        .help("Amount of XNT to put in system account to pay for fees"),
                 )
                 .arg(
                     Arg::with_name("stake_authority")

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -528,7 +528,7 @@ fn read_allocations(
             })
             .collect::<Result<Vec<TypedAllocation>, Error>>()?
     } else if with_lockup {
-        // We only support SOL token in "require lockup" mode.
+        // We only support XNT token in "require lockup" mode.
         rdr.deserialize()
             .map(|recipient| {
                 let (recipient, amount, lockup_date): (String, f64, String) = recipient?;

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -373,7 +373,7 @@ fn main() {
     } else if random_mint {
         println_name_value(
             "\nNotice!",
-            "No wallet available. `solana airdrop` localnet SOL after creating one\n",
+            "No wallet available. `solana airdrop` localnet XNT after creating one\n",
         );
     }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -935,7 +935,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                      identities. Overriding the amount of stake this validator considers as valid \
                      for other peers in network. The stake amount is used for calculating the \
                      number of QUIC streams permitted from the peer and vote packet sender stage. \
-                     Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}",
+                     Format of the file: `staked_map_id: {<pubkey>: <XNT stake amount>}",
                 ),
         )
         .arg(
@@ -2584,10 +2584,10 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
             Arg::with_name("faucet_sol")
                 .long("faucet-sol")
                 .takes_value(true)
-                .value_name("SOL")
+                .value_name("XNT")
                 .default_value(default_args.faucet_sol.as_str())
                 .help(
-                    "Give the faucet address this much SOL in genesis. If the ledger already \
+                    "Give the faucet address this much XNT in genesis. If the ledger already \
                      exists then this parameter is silently ignored",
                 ),
         )
@@ -2603,19 +2603,19 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
             Arg::with_name("faucet_per_time_sol_cap")
                 .long("faucet-per-time-sol-cap")
                 .takes_value(true)
-                .value_name("SOL")
+                .value_name("XNT")
                 .min_values(0)
                 .max_values(1)
-                .help("Per-time slice limit for faucet requests, in SOL"),
+                .help("Per-time slice limit for faucet requests, in XNT"),
         )
         .arg(
             Arg::with_name("faucet_per_request_sol_cap")
                 .long("faucet-per-request-sol-cap")
                 .takes_value(true)
-                .value_name("SOL")
+                .value_name("XNT")
                 .min_values(0)
                 .max_values(1)
-                .help("Per-request limit for faucet requests, in SOL"),
+                .help("Per-request limit for faucet requests, in XNT"),
         )
         .arg(
             Arg::with_name("geyser_plugin_config")

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -122,11 +122,11 @@ fn get_config() -> Config {
         .arg(
             Arg::with_name("minimum_validator_identity_balance")
                 .long("minimum-validator-identity-balance")
-                .value_name("SOL")
+                .value_name("XNT")
                 .takes_value(true)
                 .default_value("10")
                 .validator(is_parsable::<f64>)
-                .help("Alert when the validator identity balance is less than this amount of SOL")
+                .help("Alert when the validator identity balance is less than this amount of XNT")
         )
         .arg(
             // Deprecated parameter, now always enabled


### PR DESCRIPTION
Replace all instances of “SOL” with “XNT” across the codebase and documentation, primarily to reflect the change in CLI output.