### PR TITLE
Add v2 core BPF migration feature gates

### DIFF
--- a/CORE_BPF_MIGRATION.md
+++ b/CORE_BPF_MIGRATION.md
@@ -1,0 +1,289 @@
+# Core BPF Migration Guide for X1 Tachyon
+
+This document describes how to migrate X1's native builtin programs to Core BPF, following the same process Solana used on mainnet.
+
+Last updated: 2026-03-27
+
+---
+
+## Background
+
+Solana migrated four native builtin programs to Core BPF (SIMD-0088). The process replaces native Rust entrypoints with on-chain BPF programs, making them upgradeable via feature-gated mechanisms.
+
+On X1, the migration feature gates for config, ALT, and feature gate were activated but the source buffer accounts were never deployed, so the migrations silently failed. The native builtins continued to function on v2.2. However, v2.3+ and v3.0+ removed these builtins from the `BUILTINS` list, breaking ALT/config operations. Completing these migrations on v2.2 is a prerequisite for upgrading to v2.3 or v3.0.
+
+---
+
+## Verified Program ELFs
+
+All ELFs below have been verified by dumping the live programs from Solana mainnet (`solana -um program dump`) and comparing SHA-256 hashes against the GitHub release artifacts.
+
+| Program | GitHub Repo | Release Tag | ELF Size | SHA-256 |
+|---------|------------|-------------|----------|---------|
+| Address Lookup Table | `solana-program/address-lookup-table` | `program@v3.0.0` | 170,144 | `e264e1537c5ee1252aae1fa476c25000b641357bc6af4efab65f314160a99570` |
+| Config | `solana-program/config` | `program@v3.0.0` | 157,184 | `06dd0ed33dda54b37fbbb9df5e08d28a71aa817dbc57d7b0a57e348d2f4e34fa` |
+| Feature Gate | `solana-program/feature-gate` | `program@v0.0.1` | 72,984 | `4889655084aa7b8a58cb44f56a8396881a7329a1e3b91cebd9763cdf9ad04e88` |
+| Stake | `solana-program/stake` | `program@v1.0.0` | 232,464 | `f35947e5e5b063b5339cd6e8a18a31b837c2edce6b8b8dd7e2762611f88f55c5` |
+
+**Important:** Stake `v1.0.1` (200,208 bytes) does NOT match what's currently on Solana mainnet. Use `v1.0.0`.
+
+---
+
+## Agave Version to Program Version Mapping
+
+This table tracks which BPF program versions correspond to each Agave release, based on when Solana activated migrations and upgrades on mainnet.
+
+| Agave Version | ALT | Config | Feature Gate | Stake | Notes |
+|---------------|-----|--------|--------------|-------|-------|
+| v2.2.0 | native | native | native | native | All builtins native |
+| v2.2.1 | native | v3.0.0 (epoch 753) | v0.0.1 (epoch 752) | native | Config + FG migrated Mar 2025 |
+| v2.2.4 | v3.0.0 (epoch 762) | v3.0.0 | v0.0.1 | native | ALT migrated Mar 25 2025 |
+| v2.2.19 | v3.0.0 | v3.0.0 | v0.0.1 | v1.0.0 (epoch 823) | Stake migrated Jul 2025 |
+| v2.3.0+ | v3.0.0 | v3.0.0 | v0.0.1 | v1.0.0 | ALT+Config removed from BUILTINS |
+| v3.0.0+ | v3.0.0 | v3.0.0 | v0.0.1 | v1.0.0 | All removed from BUILTINS, native code stripped |
+
+### Pending Upgrades (not yet on Solana mainnet)
+
+| Program | New Version | Feature Gate (Solana) | Buffer Address | Status |
+|---------|-------------|----------------------|----------------|--------|
+| Stake | v1.0.1 | `vote_state_v4` / `Gx4XFcrVMt4HUvPzTpTSVkdDVgcDSjKhDN1RqRS6KDuZ` | `BM11F4hqrpinQs28sEZfzQ2fYddivYs4NEAHF6QMjkJF` | Buffer deployed, not activated |
+| Stake | v5.0.0 | `upgrade_bpf_stake_program_to_v5` / `STk5Xj8hdAx3sTzmtJ3QysKkq6X2A3yj73JtxttiRyk` | `4EBQBjw1kqF1dqUBb6fc5Ji4tCEQgNf9ESGGX3smwXwh` | Not deployed |
+
+---
+
+## X1 Mainnet Current State
+
+| Program | v1 Feature (already fired) | v2 Feature (new) | Buffer (new) | On-chain Owner | Migrated? |
+|---------|---------------------------|-------------------|--------------|----------------|-----------|
+| Stake | `8v4oWsx...` (NOT active) | *(uses v1 — not yet fired)* | `8t3vv6v...` (existing) | NativeLoader | No |
+| Config | `HJQ15Ru...` (active, failed) | `3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL` | `CxBudfBvfxeRb8XmDP1T2K1A6npYgfB8Pgo7wvQstCVj` | NativeLoader | No |
+| ALT | `8fqszxY...` (active, failed) | `CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A` | `82M86jvpwc5s8e8NsY81pNHtspFGPC6nRv8CXhP9rs9L` | NativeLoader | No |
+| Feature Gate | `7TuSw9f...` (active, failed) | `5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi` | `2onpMnm4JZekhbMsWy4PTuk6kddJuvJixz41fZFDbdJM` | N/A (stateless) | No |
+
+Config, ALT, and Feature Gate v1 features already fired but migration failed because source buffers were never deployed. New v2 feature gates have been created to retry the migration.
+
+---
+
+## Migration Steps
+
+### Step 1: Release updated v2.2 validator
+
+The v2.2 code has been updated with v2 migration feature gates and buffer addresses in `feature-set/src/lib.rs` and `builtins/src/lib.rs`. This release is **safe to deploy** — no behavior changes occur until the new features are activated. The native builtins continue to run as before.
+
+```bash
+cargo build --release
+# Deploy to all validators in the cluster
+```
+
+### Step 2: Download the verified ELFs
+
+```bash
+mkdir -p ~/core-bpf-programs && cd ~/core-bpf-programs
+
+# Address Lookup Table — v3.0.0
+gh release download program@v3.0.0 \
+  --repo solana-program/address-lookup-table \
+  --pattern "*.so"
+
+# Config — v3.0.0
+gh release download program@v3.0.0 \
+  --repo solana-program/config \
+  --pattern "*.so"
+
+# Feature Gate — v0.0.1
+gh release download program@v0.0.1 \
+  --repo solana-program/feature-gate \
+  --pattern "*.so"
+
+# Stake — v1.0.0 (NOT v1.0.1)
+gh release download program@v1.0.0 \
+  --repo solana-program/stake \
+  --pattern "*.so"
+```
+
+### Step 3: Verify the downloads
+
+```bash
+echo "e264e1537c5ee1252aae1fa476c25000b641357bc6af4efab65f314160a99570  solana_address_lookup_table_program.so" | shasum -a 256 -c
+echo "06dd0ed33dda54b37fbbb9df5e08d28a71aa817dbc57d7b0a57e348d2f4e34fa  solana_config_program.so" | shasum -a 256 -c
+echo "4889655084aa7b8a58cb44f56a8396881a7329a1e3b91cebd9763cdf9ad04e88  solana_feature_gate_program.so" | shasum -a 256 -c
+echo "f35947e5e5b063b5339cd6e8a18a31b837c2edce6b8b8dd7e2762611f88f55c5  solana_stake_program.so" | shasum -a 256 -c
+```
+
+You can also verify against Solana mainnet directly:
+
+```bash
+solana -um program dump AddressLookupTab1e1111111111111111111111111 solana_alt_ref.so
+shasum -a 256 solana_alt_ref.so solana_address_lookup_table_program.so
+# Hashes should match
+```
+
+### Step 4: Deploy buffer accounts
+
+The buffer keypair files are in `~/Documents/x1-testnet/x1_feature_gate_keys/`.
+
+```bash
+solana config set --url https://rpc.mainnet.x1.xyz
+
+# Stake — deploy to existing buffer address
+solana program write-buffer solana_stake_program.so \
+  --buffer ~/Documents/x1-testnet/x1_feature_gate_keys/migrate_stake_program_to_core_bpf_8v4oWsx9gG9rXREnejzNYyjpYF5oTP1igE7pqLDt9bKe.json
+
+# Config — deploy to new v2 buffer
+solana program write-buffer solana_config_program.so \
+  --buffer ~/Documents/x1-testnet/x1_feature_gate_keys/config_buffer_v2_CxBudfBvfxeRb8XmDP1T2K1A6npYgfB8Pgo7wvQstCVj.json
+
+# ALT — deploy to new v2 buffer
+solana program write-buffer solana_address_lookup_table_program.so \
+  --buffer ~/Documents/x1-testnet/x1_feature_gate_keys/alt_buffer_v2_82M86jvpwc5s8e8NsY81pNHtspFGPC6nRv8CXhP9rs9L.json
+
+# Feature Gate — deploy to new v2 buffer
+solana program write-buffer solana_feature_gate_program.so \
+  --buffer ~/Documents/x1-testnet/x1_feature_gate_keys/feature_gate_buffer_v2_2onpMnm4JZekhbMsWy4PTuk6kddJuvJixz41fZFDbdJM.json
+```
+
+Verify the buffers were deployed:
+
+```bash
+solana account 8t3vv6v99tQA6Gp7fVdsBH66hQMaswH5qsJVqJqo8xvG  # stake buffer
+solana account CxBudfBvfxeRb8XmDP1T2K1A6npYgfB8Pgo7wvQstCVj   # config buffer
+solana account 82M86jvpwc5s8e8NsY81pNHtspFGPC6nRv8CXhP9rs9L   # ALT buffer
+solana account 2onpMnm4JZekhbMsWy4PTuk6kddJuvJixz41fZFDbdJM   # feature gate buffer
+# All should be owned by BPFLoaderUpgradeab1e
+```
+
+### Step 5: Activate feature gates
+
+**Activate one at a time.** Wait for an epoch boundary after each activation to confirm the migration succeeds before proceeding. Monitor validator logs for:
+- `"migrate_builtin_to_core_bpf"` — success
+- `"Failed to migrate builtin"` — failure
+
+```bash
+# 1. Stake (uses existing feature gate — not yet active)
+solana feature activate 8v4oWsx9gG9rXREnejzNYyjpYF5oTP1igE7pqLDt9bKe \
+  --keypair ~/Documents/x1-testnet/x1_feature_gate_keys/migrate_stake_program_to_core_bpf_8v4oWsx9gG9rXREnejzNYyjpYF5oTP1igE7pqLDt9bKe.json
+
+# Wait for epoch boundary, verify migration success, then:
+
+# 2. Config (v2 feature gate)
+solana feature activate 3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL \
+  --keypair ~/Documents/x1-testnet/x1_feature_gate_keys/migrate_config_program_to_core_bpf_v2_3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL.json
+
+# Wait for epoch boundary, verify, then:
+
+# 3. Address Lookup Table (v2 feature gate)
+solana feature activate CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A \
+  --keypair ~/Documents/x1-testnet/x1_feature_gate_keys/migrate_address_lookup_table_program_to_core_bpf_v2_CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A.json
+
+# Wait for epoch boundary, verify, then:
+
+# 4. Feature Gate (v2 feature gate)
+solana feature activate 5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi \
+  --keypair ~/Documents/x1-testnet/x1_feature_gate_keys/migrate_feature_gate_program_to_core_bpf_v2_5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi.json
+```
+
+### Step 6: Verify migrations
+
+After each activation and epoch boundary, confirm the program is now BPF:
+
+```bash
+solana -u https://rpc.mainnet.x1.xyz account Stake11111111111111111111111111111111111111
+# Owner should be: BPFLoaderUpgradeab1e11111111111111111111111
+
+solana -u https://rpc.mainnet.x1.xyz account Config1111111111111111111111111111111111111
+solana -u https://rpc.mainnet.x1.xyz account AddressLookupTab1e1111111111111111111111111
+```
+
+Also dump and verify the on-chain ELF matches what you deployed:
+
+```bash
+solana -u https://rpc.mainnet.x1.xyz program dump Stake11111111111111111111111111111111111111 x1_stake.so
+echo "f35947e5e5b063b5339cd6e8a18a31b837c2edce6b8b8dd7e2762611f88f55c5  x1_stake.so" | shasum -a 256 -c
+```
+
+---
+
+## What Happens After Migration
+
+Once all four migrations are complete:
+
+- All programs run as BPF on-chain, matching Solana mainnet
+- The `BUILTINS` entries with native entrypoints are skipped (runtime detects `owner == BPFLoaderUpgradeab1e`)
+- The codebase is ready to upgrade to **v2.3 or v3.0** — those versions removed these builtins from the `BUILTINS` list, which is now safe because the programs are BPF
+- The v3.0 fee calculation fix (checking `FeatureSet` for migration status) becomes a no-op since `migrate_stake_program_to_core_bpf` will be active
+
+---
+
+## Upgrade Path After Initial Migration
+
+Once migrated, programs can be upgraded via the `upgrade_core_bpf_program` mechanism:
+
+1. Build/obtain the new ELF version
+2. Deploy to a new buffer account on X1 mainnet
+3. Add a new feature gate to `feature-set/src/lib.rs`
+4. Add the upgrade config to the runtime (similar to migration config)
+5. Deploy updated validator
+6. Activate the upgrade feature gate
+7. At next epoch boundary, the runtime swaps the ELF
+
+All migrated programs have `upgrade_authority: None`, so they can ONLY be upgraded through this feature-gate mechanism, not through normal `solana program upgrade`.
+
+---
+
+## Verification: Dumping On-Chain Programs
+
+To verify programs match expected ELFs at any time:
+
+```bash
+# Dump from Solana mainnet (reference)
+solana -um program dump AddressLookupTab1e1111111111111111111111111 solana_alt.so
+solana -um program dump Config1111111111111111111111111111111111111 solana_config.so
+solana -um program dump Stake11111111111111111111111111111111111111 solana_stake.so
+solana -um program dump Feature111111111111111111111111111111111111 solana_feature_gate.so
+
+# Dump from X1 mainnet (after migration)
+solana -u https://rpc.mainnet.x1.xyz program dump AddressLookupTab1e1111111111111111111111111 x1_alt.so
+solana -u https://rpc.mainnet.x1.xyz program dump Config1111111111111111111111111111111111111 x1_config.so
+solana -u https://rpc.mainnet.x1.xyz program dump Stake11111111111111111111111111111111111111 x1_stake.so
+
+# Compare
+shasum -a 256 solana_alt.so x1_alt.so
+shasum -a 256 solana_config.so x1_config.so
+shasum -a 256 solana_stake.so x1_stake.so
+```
+
+---
+
+## Keypair Inventory
+
+All keypairs are stored in `~/Documents/x1-testnet/x1_feature_gate_keys/`.
+
+### Feature Gate Keypairs
+
+| Purpose | File | Pubkey |
+|---------|------|--------|
+| Stake migration (v1) | `migrate_stake_program_to_core_bpf_8v4oWsx9gG9rXREnejzNYyjpYF5oTP1igE7pqLDt9bKe.json` | `8v4oWsx9gG9rXREnejzNYyjpYF5oTP1igE7pqLDt9bKe` |
+| Config migration (v2) | `migrate_config_program_to_core_bpf_v2_3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL.json` | `3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL` |
+| ALT migration (v2) | `migrate_address_lookup_table_program_to_core_bpf_v2_CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A.json` | `CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A` |
+| Feature Gate migration (v2) | `migrate_feature_gate_program_to_core_bpf_v2_5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi.json` | `5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi` |
+
+### Buffer Keypairs
+
+| Purpose | File | Pubkey |
+|---------|------|--------|
+| Stake buffer (v1) | *(existing — see keypair inventory)* | `8t3vv6v99tQA6Gp7fVdsBH66hQMaswH5qsJVqJqo8xvG` |
+| Config buffer (v2) | `config_buffer_v2_CxBudfBvfxeRb8XmDP1T2K1A6npYgfB8Pgo7wvQstCVj.json` | `CxBudfBvfxeRb8XmDP1T2K1A6npYgfB8Pgo7wvQstCVj` |
+| ALT buffer (v2) | `alt_buffer_v2_82M86jvpwc5s8e8NsY81pNHtspFGPC6nRv8CXhP9rs9L.json` | `82M86jvpwc5s8e8NsY81pNHtspFGPC6nRv8CXhP9rs9L` |
+| Feature Gate buffer (v2) | `feature_gate_buffer_v2_2onpMnm4JZekhbMsWy4PTuk6kddJuvJixz41fZFDbdJM.json` | `2onpMnm4JZekhbMsWy4PTuk6kddJuvJixz41fZFDbdJM` |
+
+---
+
+## References
+
+- [SIMD-0088: Enable Core BPF Programs](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0088-enable-core-bpf-programs.md)
+- [SIMD-0128: Migrate ALT to Core BPF](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0128-migrate-address-lookup-table-to-core-bpf.md)
+- [SIMD-0140: Migrate Config to Core BPF](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0140-migrate-config-to-core-bpf.md)
+- [Agave fetch-core-bpf.sh](https://github.com/anza-xyz/agave/blob/master/fetch-core-bpf.sh)
+- [Core BPF Migration Project Board](https://github.com/orgs/solana-program/projects/5)
+- Migration runtime code: `runtime/src/bank/builtins/core_bpf_migration/mod.rs`
+- Builtin configs: `builtins/src/lib.rs`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agave-accounts-hash-cache-tool"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-cargo-registry"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "flate2",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-clock",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "atty",
  "bincode",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-histogram"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "solana-version",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-tool"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "clap 2.33.3",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "affinity",
  "agave-thread-manager",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -1040,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "regex",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "regex",
 ]
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "rdrand"
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6102,7 +6102,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -6154,7 +6154,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-program",
  "static_assertions",
  "strum",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6201,13 +6201,13 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "assert_matches",
@@ -6269,7 +6269,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
@@ -6278,7 +6278,7 @@ dependencies = [
  "solana-program",
  "solana-runtime",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -6287,18 +6287,18 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "chrono",
@@ -6376,7 +6376,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-vote"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6428,7 +6428,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bv",
  "fnv",
@@ -6473,7 +6473,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6524,7 +6524,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "static_assertions",
  "test-case",
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6566,7 +6566,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "solana-address-lookup-table-program",
@@ -6586,7 +6586,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6611,7 +6611,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_cmd",
  "bzip2",
@@ -6632,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -6706,7 +6706,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -6816,7 +6816,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -6852,7 +6852,7 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote-program",
@@ -6861,7 +6861,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "futures-util",
  "rand 0.8.5",
@@ -6992,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
@@ -7002,7 +7002,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -7052,7 +7052,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program-bench"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "criterion",
@@ -7067,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "chrono",
@@ -7087,12 +7087,12 @@ dependencies = [
  "solana-signer",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7227,7 +7227,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -7358,7 +7358,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-clock",
@@ -7384,7 +7384,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7396,7 +7396,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-reserved-account-keys",
  "assert_matches",
@@ -7503,7 +7503,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -7582,7 +7582,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -7634,7 +7634,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-v0"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7812,7 +7812,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7916,7 +7916,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -7973,7 +7973,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -8029,7 +8029,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -8103,7 +8103,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "log",
@@ -8219,13 +8219,13 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-local-cluster"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "byte-unit",
  "clap 3.2.23",
@@ -8281,7 +8281,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
 ]
@@ -8301,15 +8301,15 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "solana-memory-management"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -8322,7 +8322,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "fast-math",
  "hex",
@@ -8358,7 +8358,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -8392,7 +8392,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-shaper"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 3.2.23",
  "rand 0.8.5",
@@ -8404,7 +8404,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "reqwest",
@@ -8501,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -8545,7 +8545,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 3.2.23",
  "log",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -8822,7 +8822,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "test-case",
  "thiserror 2.0.11",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -8859,7 +8859,7 @@ dependencies = [
  "solana-stake-program",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-program",
  "test-case",
  "thiserror 2.0.11",
@@ -8897,7 +8897,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8924,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -8974,7 +8974,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "console",
@@ -9065,7 +9065,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9115,7 +9115,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -9180,7 +9180,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "bs58",
@@ -9277,7 +9277,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -9361,7 +9361,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -9380,7 +9380,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9597,7 +9597,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -9741,7 +9741,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -9780,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -9808,7 +9808,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-sysvar",
  "solana-sysvar-id",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "solana-vote-interface",
  "solana-vote-program",
@@ -9817,7 +9817,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program-tests"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -9830,7 +9830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -9863,7 +9863,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-transaction-status",
  "thiserror 2.0.11",
@@ -9874,7 +9874,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "bs58",
@@ -9890,7 +9890,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -9898,7 +9898,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -9947,7 +9947,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -10016,7 +10016,7 @@ dependencies = [
  "solana-sysvar",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-type-overrides",
  "test-case",
@@ -10025,7 +10025,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-conformance"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "prost",
  "prost-build",
@@ -10034,15 +10034,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -10073,7 +10073,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10100,7 +10100,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
 ]
 
@@ -10170,7 +10170,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "log",
@@ -10236,7 +10236,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -10245,7 +10245,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "rustls 0.23.22",
  "solana-keypair",
@@ -10256,7 +10256,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -10290,7 +10290,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "serial_test",
@@ -10323,7 +10323,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -10355,7 +10355,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -10432,7 +10432,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "serde",
@@ -10445,13 +10445,13 @@ dependencies = [
  "solana-rent",
  "solana-signature",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "static_assertions",
 ]
 
 [[package]]
 name = "solana-transaction-dos"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -10492,7 +10492,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10511,7 +10511,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -10553,7 +10553,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10567,14 +10567,14 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10618,7 +10618,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "futures 0.3.31",
  "lazy_static",
@@ -10628,7 +10628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10643,7 +10643,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "solana-instruction",
@@ -10656,7 +10656,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10693,7 +10693,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -10707,7 +10707,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "semver 1.0.25",
@@ -10721,7 +10721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vortexor"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -10764,7 +10764,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10820,7 +10820,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10852,7 +10852,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-interface",
  "test-case",
  "thiserror 2.0.11",
@@ -10860,7 +10860,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -10895,7 +10895,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10910,7 +10910,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-keygen"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -10929,7 +10929,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -10966,7 +10966,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10983,7 +10983,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program-tests"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "curve25519-dalek 4.1.3",
@@ -11003,7 +11003,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -11617,7 +11617,7 @@ dependencies = [
 
 [[package]]
 name = "tachyon-ledger-tool"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -11665,7 +11665,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-unified-scheduler-pool",
@@ -11678,7 +11678,7 @@ dependencies = [
 
 [[package]]
 name = "tachyon-validator"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ exclude = ["programs/sbf", "svm/examples", "svm/tests/example-programs"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.18"
+version = "2.2.19"
 authors = ["X1 Labs maintainers <maintainers@x1.xyz>"]
 repository = "https://github.com/x1-labs/tachyon"
 homepage = "https://x1.xyz/"
@@ -168,14 +168,14 @@ check-cfg = [
 [workspace.dependencies]
 Inflector = "0.11.4"
 aes-gcm-siv = "0.11.1"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.2.18" }
-agave-cargo-registry = { path = "cargo-registry", version = "=2.2.18" }
-agave-feature-set = { path = "feature-set", version = "=2.2.18" }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.2.18" }
-agave-precompiles = { path = "precompiles", version = "=2.2.18" }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.2.18" }
-agave-thread-manager = { path = "thread-manager", version = "=2.2.18" }
-agave-transaction-view = { path = "transaction-view", version = "=2.2.18" }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.2.19" }
+agave-cargo-registry = { path = "cargo-registry", version = "=2.2.19" }
+agave-feature-set = { path = "feature-set", version = "=2.2.19" }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.2.19" }
+agave-precompiles = { path = "precompiles", version = "=2.2.19" }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.2.19" }
+agave-thread-manager = { path = "thread-manager", version = "=2.2.19" }
+agave-transaction-view = { path = "transaction-view", version = "=2.2.19" }
 ahash = "0.8.11"
 anyhow = "1.0.95"
 aquamarine = "0.6.0"
@@ -358,110 +358,110 @@ smpl_jwt = "0.7.1"
 socket2 = "0.5.8"
 soketto = "0.7"
 solana-account = "2.2.1"
-solana-account-decoder = { path = "account-decoder", version = "=2.2.18" }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.2.18" }
+solana-account-decoder = { path = "account-decoder", version = "=2.2.19" }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.2.19" }
 solana-account-info = "2.2.1"
-solana-accounts-db = { path = "accounts-db", version = "=2.2.18" }
+solana-accounts-db = { path = "accounts-db", version = "=2.2.19" }
 solana-address-lookup-table-interface = "2.2.2"
-solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.2.18" }
+solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.2.19" }
 solana-atomic-u64 = "2.2.1"
-solana-banks-client = { path = "banks-client", version = "=2.2.18" }
-solana-banks-interface = { path = "banks-interface", version = "=2.2.18" }
-solana-banks-server = { path = "banks-server", version = "=2.2.18" }
-solana-bench-tps = { path = "bench-tps", version = "=2.2.18" }
+solana-banks-client = { path = "banks-client", version = "=2.2.19" }
+solana-banks-interface = { path = "banks-interface", version = "=2.2.19" }
+solana-banks-server = { path = "banks-server", version = "=2.2.19" }
+solana-bench-tps = { path = "bench-tps", version = "=2.2.19" }
 solana-big-mod-exp = "2.2.1"
 solana-bincode = "2.2.1"
 solana-blake3-hasher = "2.2.1"
-solana-bloom = { path = "bloom", version = "=2.2.18" }
+solana-bloom = { path = "bloom", version = "=2.2.19" }
 solana-bn254 = "2.2.2"
 solana-borsh = "2.2.1"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.2.18" }
-solana-bucket-map = { path = "bucket_map", version = "=2.2.18" }
-solana-builtins = { path = "builtins", version = "=2.2.18" }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.2.18" }
-solana-clap-utils = { path = "clap-utils", version = "=2.2.18" }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.2.18" }
-solana-cli = { path = "cli", version = "=2.2.18" }
-solana-cli-config = { path = "cli-config", version = "=2.2.18" }
-solana-cli-output = { path = "cli-output", version = "=2.2.18" }
-solana-client = { path = "client", version = "=2.2.18" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.2.19" }
+solana-bucket-map = { path = "bucket_map", version = "=2.2.19" }
+solana-builtins = { path = "builtins", version = "=2.2.19" }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.2.19" }
+solana-clap-utils = { path = "clap-utils", version = "=2.2.19" }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.2.19" }
+solana-cli = { path = "cli", version = "=2.2.19" }
+solana-cli-config = { path = "cli-config", version = "=2.2.19" }
+solana-cli-output = { path = "cli-output", version = "=2.2.19" }
+solana-client = { path = "client", version = "=2.2.19" }
 solana-client-traits = "2.2.1"
 solana-clock = "2.2.1"
 solana-cluster-type = "2.2.1"
 solana-commitment-config = "2.2.1"
-solana-compute-budget = { path = "compute-budget", version = "=2.2.18" }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.2.18" }
+solana-compute-budget = { path = "compute-budget", version = "=2.2.19" }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.2.19" }
 solana-compute-budget-interface = "2.2.1"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.2.18" }
-solana-config-program = { path = "programs/config", version = "=2.2.18" }
-solana-connection-cache = { path = "connection-cache", version = "=2.2.18", default-features = false }
-solana-core = { path = "core", version = "=2.2.18" }
-solana-cost-model = { path = "cost-model", version = "=2.2.18" }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.2.19" }
+solana-config-program = { path = "programs/config", version = "=2.2.19" }
+solana-connection-cache = { path = "connection-cache", version = "=2.2.19", default-features = false }
+solana-core = { path = "core", version = "=2.2.19" }
+solana-cost-model = { path = "cost-model", version = "=2.2.19" }
 solana-cpi = "2.2.1"
-solana-curve25519 = { path = "curves/curve25519", version = "=2.2.18" }
+solana-curve25519 = { path = "curves/curve25519", version = "=2.2.19" }
 solana-decode-error = "2.2.1"
 solana-define-syscall = "2.2.1"
 solana-derivation-path = "2.2.1"
-solana-download-utils = { path = "download-utils", version = "=2.2.18" }
+solana-download-utils = { path = "download-utils", version = "=2.2.19" }
 solana-ed25519-program = "2.2.2"
-solana-entry = { path = "entry", version = "=2.2.18" }
+solana-entry = { path = "entry", version = "=2.2.19" }
 solana-epoch-info = "2.2.1"
 solana-epoch-rewards = "2.2.1"
 solana-epoch-rewards-hasher = "2.2.1"
 solana-epoch-schedule = "2.2.1"
 solana-example-mocks = "2.2.1"
-solana-faucet = { path = "faucet", version = "=2.2.18" }
+solana-faucet = { path = "faucet", version = "=2.2.19" }
 solana-feature-gate-client = "0.0.2"
 solana-feature-gate-interface = "2.2.2"
 solana-fee-calculator = "2.2.1"
-solana-fee = { path = "fee", version = "=2.2.18" }
-solana-fee-v0 = { path = "fee-v0", version = "=2.2.18" }
+solana-fee = { path = "fee", version = "=2.2.19" }
+solana-fee-v0 = { path = "fee-v0", version = "=2.2.19" }
 solana-fee-structure = "2.2.1"
 solana-file-download = "2.2.1"
 solana-frozen-abi = "2.2.1"
 solana-frozen-abi-macro = "2.2.1"
-solana-genesis = { path = "genesis", version = "=2.2.18" }
+solana-genesis = { path = "genesis", version = "=2.2.19" }
 solana-genesis-config = "2.2.1"
-solana-genesis-utils = { path = "genesis-utils", version = "=2.2.18" }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.2.18" }
-solana-gossip = { path = "gossip", version = "=2.2.18" }
+solana-genesis-utils = { path = "genesis-utils", version = "=2.2.19" }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.2.19" }
+solana-gossip = { path = "gossip", version = "=2.2.19" }
 solana-hard-forks = "2.2.1"
 solana-hash = "2.2.1"
 solana-inflation = "2.2.1"
-solana-inline-spl = { path = "inline-spl", version = "=2.2.18" }
+solana-inline-spl = { path = "inline-spl", version = "=2.2.19" }
 solana-instruction = "2.2.1"
 solana-instructions-sysvar = "2.2.1"
 solana-keccak-hasher = "2.2.1"
 solana-keypair = "2.2.1"
 solana-last-restart-slot = "2.2.1"
-solana-lattice-hash = { path = "lattice-hash", version = "=2.2.18" }
-solana-ledger = { path = "ledger", version = "=2.2.18" }
+solana-lattice-hash = { path = "lattice-hash", version = "=2.2.19" }
+solana-ledger = { path = "ledger", version = "=2.2.19" }
 solana-loader-v2-interface = "2.2.1"
 solana-loader-v3-interface = "5.0.0"
 solana-loader-v4-interface = "2.2.1"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.2.18" }
-solana-local-cluster = { path = "local-cluster", version = "=2.2.18" }
-solana-log-collector = { path = "log-collector", version = "=2.2.18" }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.2.19" }
+solana-local-cluster = { path = "local-cluster", version = "=2.2.19" }
+solana-log-collector = { path = "log-collector", version = "=2.2.19" }
 solana-logger = "2.3.1"
-solana-measure = { path = "measure", version = "=2.2.18" }
-solana-merkle-tree = { path = "merkle-tree", version = "=2.2.18" }
+solana-measure = { path = "measure", version = "=2.2.19" }
+solana-merkle-tree = { path = "merkle-tree", version = "=2.2.19" }
 solana-message = "2.2.1"
-solana-metrics = { path = "metrics", version = "=2.2.18" }
+solana-metrics = { path = "metrics", version = "=2.2.19" }
 solana-msg = "2.2.1"
 solana-native-token = "2.2.1"
-solana-net-utils = { path = "net-utils", version = "=2.2.18" }
+solana-net-utils = { path = "net-utils", version = "=2.2.19" }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "2.2.1"
 solana-nonce-account = "2.2.1"
-solana-notifier = { path = "notifier", version = "=2.2.18" }
+solana-notifier = { path = "notifier", version = "=2.2.19" }
 solana-offchain-message = "2.2.1"
 solana-package-metadata = "2.2.1"
 solana-package-metadata-macro = "2.2.1"
 solana-packet = "2.2.1"
-solana-perf = { path = "perf", version = "=2.2.18" }
-solana-poh = { path = "poh", version = "=2.2.18" }
+solana-perf = { path = "perf", version = "=2.2.19" }
+solana-poh = { path = "poh", version = "=2.2.19" }
 solana-poh-config = "2.2.1"
-solana-poseidon = { path = "poseidon", version = "=2.2.18" }
+solana-poseidon = { path = "poseidon", version = "=2.2.19" }
 solana-precompile-error = "2.2.1"
 solana-presigner = "2.2.1"
 solana-program = { version = "2.2.1", default-features = false }
@@ -470,24 +470,24 @@ solana-program-error = "2.2.1"
 solana-program-memory = "2.2.1"
 solana-program-option = "2.2.1"
 solana-program-pack = "2.2.1"
-solana-program-runtime = { path = "program-runtime", version = "=2.2.18" }
-solana-program-test = { path = "program-test", version = "=2.2.18" }
+solana-program-runtime = { path = "program-runtime", version = "=2.2.19" }
+solana-program-test = { path = "program-test", version = "=2.2.19" }
 solana-pubkey = { version = "2.2.1", default-features = false }
-solana-pubsub-client = { path = "pubsub-client", version = "=2.2.18" }
-solana-quic-client = { path = "quic-client", version = "=2.2.18" }
+solana-pubsub-client = { path = "pubsub-client", version = "=2.2.19" }
+solana-quic-client = { path = "quic-client", version = "=2.2.19" }
 solana-quic-definitions = "2.2.1"
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.18" }
-solana-remote-wallet = { path = "remote-wallet", version = "=2.2.18", default-features = false }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.19" }
+solana-remote-wallet = { path = "remote-wallet", version = "=2.2.19", default-features = false }
 solana-rent = "2.2.1"
 solana-rent-collector = "2.2.1"
 solana-rent-debits = "2.2.1"
 solana-reward-info = "2.2.1"
-solana-rpc = { path = "rpc", version = "=2.2.18" }
-solana-rpc-client = { path = "rpc-client", version = "=2.2.18", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.18" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.18" }
-solana-runtime = { path = "runtime", version = "=2.2.18" }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.18" }
+solana-rpc = { path = "rpc", version = "=2.2.19" }
+solana-rpc-client = { path = "rpc-client", version = "=2.2.19", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.19" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.19" }
+solana-runtime = { path = "runtime", version = "=2.2.19" }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.19" }
 solana-sanitize = "2.2.1"
 solana-sbpf = "=0.10.1"
 solana-sdk = "2.2.2"
@@ -498,7 +498,7 @@ solana-secp256k1-recover = "2.2.1"
 solana-secp256r1-program = "2.2.2"
 solana-seed-derivable = "2.2.1"
 solana-seed-phrase = "2.2.1"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=2.2.18" }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=2.2.19" }
 solana-serde = "2.2.1"
 solana-serde-varint = "2.2.1"
 solana-serialize-utils = "2.2.1"
@@ -511,49 +511,49 @@ solana-slot-hashes = "2.2.1"
 solana-slot-history = "2.2.1"
 solana-stable-layout = "2.2.1"
 solana-stake-interface = { version = "1.2.1" }
-solana-stake-program = { path = "programs/stake", version = "=2.2.18" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.18" }
-solana-storage-proto = { path = "storage-proto", version = "=2.2.18" }
-solana-streamer = { path = "streamer", version = "=2.2.18" }
-solana-svm = { path = "svm", version = "=2.2.18" }
-solana-svm-conformance = { path = "svm-conformance", version = "=2.2.18" }
-solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.18" }
-solana-svm-transaction = { path = "svm-transaction", version = "=2.2.18" }
+solana-stake-program = { path = "programs/stake", version = "=2.2.19" }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.19" }
+solana-storage-proto = { path = "storage-proto", version = "=2.2.19" }
+solana-streamer = { path = "streamer", version = "=2.2.19" }
+solana-svm = { path = "svm", version = "=2.2.19" }
+solana-svm-conformance = { path = "svm-conformance", version = "=2.2.19" }
+solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.19" }
+solana-svm-transaction = { path = "svm-transaction", version = "=2.2.19" }
 solana-system-interface = "1.0"
-solana-system-program = { path = "programs/system", version = "=2.2.18" }
+solana-system-program = { path = "programs/system", version = "=2.2.19" }
 solana-system-transaction = "2.2.1"
 solana-sysvar = "2.2.1"
 solana-sysvar-id = "2.2.1"
-solana-test-validator = { path = "test-validator", version = "=2.2.18" }
-solana-thin-client = { path = "thin-client", version = "=2.2.18" }
+solana-test-validator = { path = "test-validator", version = "=2.2.19" }
+solana-thin-client = { path = "thin-client", version = "=2.2.19" }
 solana-time-utils = "2.2.1"
-solana-timings = { path = "timings", version = "=2.2.18" }
-solana-tls-utils = { path = "tls-utils", version = "=2.2.18" }
-solana-tps-client = { path = "tps-client", version = "=2.2.18" }
-solana-tpu-client = { path = "tpu-client", version = "=2.2.18", default-features = false }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.18" }
+solana-timings = { path = "timings", version = "=2.2.19" }
+solana-tls-utils = { path = "tls-utils", version = "=2.2.19" }
+solana-tps-client = { path = "tps-client", version = "=2.2.19" }
+solana-tpu-client = { path = "tpu-client", version = "=2.2.19", default-features = false }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.19" }
 solana-transaction = "2.2.2"
-solana-transaction-context = { path = "transaction-context", version = "=2.2.18", features = [ "bincode" ] }
+solana-transaction-context = { path = "transaction-context", version = "=2.2.19", features = [ "bincode" ] }
 solana-transaction-error = "2.2.1"
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.18" }
-solana-transaction-status = { path = "transaction-status", version = "=2.2.18" }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.18" }
-solana-turbine = { path = "turbine", version = "=2.2.18" }
-solana-type-overrides = { path = "type-overrides", version = "=2.2.18" }
-solana-udp-client = { path = "udp-client", version = "=2.2.18" }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.2.18" }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.2.18" }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.19" }
+solana-transaction-status = { path = "transaction-status", version = "=2.2.19" }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.19" }
+solana-turbine = { path = "turbine", version = "=2.2.19" }
+solana-type-overrides = { path = "type-overrides", version = "=2.2.19" }
+solana-udp-client = { path = "udp-client", version = "=2.2.19" }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.2.19" }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.2.19" }
 solana-validator-exit = "2.2.1"
-solana-version = { path = "version", version = "=2.2.18" }
-solana-vote = { path = "vote", version = "=2.2.18" }
+solana-version = { path = "version", version = "=2.2.19" }
+solana-vote = { path = "vote", version = "=2.2.19" }
 solana-vote-interface = "2.2.3"
-solana-vote-program = { path = "programs/vote", version = "=2.2.18", default-features = false }
-solana-wen-restart = { path = "wen-restart", version = "=2.2.18" }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.2.18" }
-solana-zk-keygen = { path = "zk-keygen", version = "=2.2.18" }
-solana-zk-sdk = { path = "zk-sdk", version = "=2.2.18" }
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.2.18" }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.2.18" }
+solana-vote-program = { path = "programs/vote", version = "=2.2.19", default-features = false }
+solana-wen-restart = { path = "wen-restart", version = "=2.2.19" }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.2.19" }
+solana-zk-keygen = { path = "zk-keygen", version = "=2.2.19" }
+solana-zk-sdk = { path = "zk-sdk", version = "=2.2.19" }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.2.19" }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.2.19" }
 spl-associated-token-account = "6.0.0"
 spl-instruction-padding = "0.3"
 spl-memo = "6.0.0"

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -79,9 +79,9 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
     },
     BuiltinPrototype {
         core_bpf_migration_config: Some(CoreBpfMigrationConfig {
-            source_buffer_address: buffer_accounts::config_program::id(),
+            source_buffer_address: buffer_accounts::config_program_v2::id(),
             upgrade_authority_address: None,
-            feature_id: agave_feature_set::migrate_config_program_to_core_bpf::id(),
+            feature_id: agave_feature_set::migrate_config_program_to_core_bpf_v2::id(),
             migration_target: CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_config_program",
         }),
@@ -120,9 +120,9 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
     }),
     BuiltinPrototype {
         core_bpf_migration_config: Some(CoreBpfMigrationConfig {
-            source_buffer_address: buffer_accounts::address_lookup_table_program::id(),
+            source_buffer_address: buffer_accounts::address_lookup_table_program_v2::id(),
             upgrade_authority_address: None,
-            feature_id: agave_feature_set::migrate_address_lookup_table_program_to_core_bpf::id(),
+            feature_id: agave_feature_set::migrate_address_lookup_table_program_to_core_bpf_v2::id(),
             migration_target: CoreBpfMigrationTargetType::Builtin,
             datapoint_name: "migrate_builtin_to_core_bpf_address_lookup_table_program",
         }),
@@ -156,9 +156,9 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
 
 pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[StatelessBuiltinPrototype {
     core_bpf_migration_config: Some(CoreBpfMigrationConfig {
-        source_buffer_address: buffer_accounts::feature_gate_program::id(),
+        source_buffer_address: buffer_accounts::feature_gate_program_v2::id(),
         upgrade_authority_address: None,
-        feature_id: agave_feature_set::migrate_feature_gate_program_to_core_bpf::id(),
+        feature_id: agave_feature_set::migrate_feature_gate_program_to_core_bpf_v2::id(),
         migration_target: CoreBpfMigrationTargetType::Stateless,
         datapoint_name: "migrate_stateless_to_core_bpf_feature_gate_program",
     }),
@@ -168,6 +168,7 @@ pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[StatelessBuiltin
 
 /// Live source buffer accounts for builtin migrations.
 mod buffer_accounts {
+    // Original buffer addresses (v1 migration attempts — failed on X1)
     pub mod address_lookup_table_program {
         solana_pubkey::declare_id!("AhXWrD9BBUYcKjtpA3zuiiZG4ysbo6C6wjHo1QhERk6A");
     }
@@ -179,6 +180,17 @@ mod buffer_accounts {
     }
     pub mod stake_program {
         solana_pubkey::declare_id!("8t3vv6v99tQA6Gp7fVdsBH66hQMaswH5qsJVqJqo8xvG");
+    }
+
+    // New buffer addresses for v2 migration (X1-specific retry)
+    pub mod config_program_v2 {
+        solana_pubkey::declare_id!("CxBudfBvfxeRb8XmDP1T2K1A6npYgfB8Pgo7wvQstCVj");
+    }
+    pub mod address_lookup_table_program_v2 {
+        solana_pubkey::declare_id!("82M86jvpwc5s8e8NsY81pNHtspFGPC6nRv8CXhP9rs9L");
+    }
+    pub mod feature_gate_program_v2 {
+        solana_pubkey::declare_id!("2onpMnm4JZekhbMsWy4PTuk6kddJuvJixz41fZFDbdJM");
     }
 }
 

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -208,7 +208,7 @@ where
 
 pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
     match url_or_moniker.as_ref() {
-        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "m" | "mainnet-beta" => "https://rpc.mainnet.x1.xyz",
         "t" | "testnet" => "https://rpc.testnet.x1.xyz",
         "d" | "devnet" => "https://rpc.testnet.x1.xyz",
         "l" | "localhost" => "http://localhost:8899",

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -252,7 +252,7 @@ where
 
 pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
     match url_or_moniker.as_ref() {
-        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "m" | "mainnet-beta" => "https://rpc.mainnet.x1.xyz",
         "t" | "testnet" => "https://rpc.testnet.x1.xyz",
         "d" | "devnet" => "https://api.devnet.solana.com",
         "l" | "localhost" => "http://localhost:8899",

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -73,7 +73,7 @@ impl Default for Config {
             keypair_path.extend([".config", "solana", "id.json"]);
             keypair_path.to_str().unwrap().to_string()
         };
-        let json_rpc_url = "https://api.mainnet-beta.solana.com".to_string();
+        let json_rpc_url = "https://rpc.mainnet.x1.xyz".to_string();
 
         // Empty websocket_url string indicates the client should
         // `Config::compute_websocket_url(&json_rpc_url)`

--- a/docs/src/cli/wallets/paper.md
+++ b/docs/src/cli/wallets/paper.md
@@ -195,7 +195,7 @@ Next, configure the `solana` CLI tool to
 [connect to a particular cluster](../examples/choose-a-cluster.md):
 
 ```bash
-solana config set --url <CLUSTER URL> # (i.e. https://api.mainnet-beta.solana.com)
+solana config set --url <CLUSTER URL> # (i.e. https://rpc.mainnet.x1.xyz)
 ```
 
 Finally, to check the balance, run the following command:

--- a/docs/src/clusters/available.md
+++ b/docs/src/clusters/available.md
@@ -137,12 +137,12 @@ A permissionless, persistent cluster for Solana users, builders, validators and 
 export SOLANA_METRICS_CONFIG="host=https://metrics.solana.com:8086,db=mainnet-beta,u=mainnet-beta_write,p=password"
 ```
 
-- RPC URL for Mainnet Beta: `https://api.mainnet-beta.solana.com`
+- RPC URL for Mainnet Beta: `https://rpc.mainnet.x1.xyz`
 
 ##### Example `solana` command-line configuration
 
 ```bash
-solana config set --url https://api.mainnet-beta.solana.com
+solana config set --url https://rpc.mainnet.x1.xyz
 ```
 
 ##### Example `tachyon-validator` command-line

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1072,6 +1072,18 @@ pub mod enable_native_mint_wrap_account {
     solana_pubkey::declare_id!("BeCY6VL4CKQR2QUwe9w3iRtNMN91FMW1sXbRzwfc3WYc");
 }
 
+pub mod migrate_config_program_to_core_bpf_v2 {
+    solana_pubkey::declare_id!("3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL");
+}
+
+pub mod migrate_address_lookup_table_program_to_core_bpf_v2 {
+    solana_pubkey::declare_id!("CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A");
+}
+
+pub mod migrate_feature_gate_program_to_core_bpf_v2 {
+    solana_pubkey::declare_id!("5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1267,10 +1279,13 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (abort_on_invalid_curve::id(), "Abort when elliptic curve syscalls invoked on invalid curve id SIMD-0137"),
         (get_sysvar_syscall_enabled::id(), "Enable syscall for fetching Sysvar bytes #615"),
         (migrate_feature_gate_program_to_core_bpf::id(), "Migrate Feature Gate program to Core BPF (programify) #1003"),
+        (migrate_feature_gate_program_to_core_bpf_v2::id(), "Migrate Feature Gate program to Core BPF v2"),
         (vote_only_full_fec_sets::id(), "vote only full fec sets"),
         (migrate_config_program_to_core_bpf::id(), "Migrate Config program to Core BPF #1378"),
+        (migrate_config_program_to_core_bpf_v2::id(), "Migrate Config program to Core BPF v2"),
         (enable_get_epoch_stake_syscall::id(), "Enable syscall: sol_get_epoch_stake #884"),
         (migrate_address_lookup_table_program_to_core_bpf::id(), "Migrate Address Lookup Table program to Core BPF #1651"),
+        (migrate_address_lookup_table_program_to_core_bpf_v2::id(), "Migrate Address Lookup Table program to Core BPF v2"),
         (zk_elgamal_proof_program_enabled::id(), "Enable ZkElGamalProof program SIMD-0153"),
         (verify_retransmitter_signature::id(), "Verify retransmitter signature #1840"),
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),

--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -142,7 +142,7 @@ mod test {
     #[test]
     fn test_save() {
         let root_dir = env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
-        let json_rpc_url = "https://api.mainnet-beta.solana.com";
+        let json_rpc_url = "https://rpc.mainnet.x1.xyz";
         let pubkey = Pubkey::default();
         let config_name = "config.yaml";
         let config_path = format!("{root_dir}/{config_name}");
@@ -158,7 +158,7 @@ mod test {
             read_to_string(&config_path).unwrap(),
             format!(
                 "---
-json_rpc_url: https://api.mainnet-beta.solana.com
+json_rpc_url: https://rpc.mainnet.x1.xyz
 update_manifest_pubkey:
 - 0
 - 0

--- a/multinode-demo/setup-from-mainnet-beta.sh
+++ b/multinode-demo/setup-from-mainnet-beta.sh
@@ -11,8 +11,8 @@ mkdir -p "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot
 (
   cd "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot || exit 1
   set -x
-  wget http://api.mainnet-beta.solana.com/genesis.tar.bz2
-  wget --trust-server-names http://api.mainnet-beta.solana.com/snapshot.tar.bz2
+  wget http://rpc.mainnet.x1.xyz/genesis.tar.bz2
+  wget --trust-server-names http://rpc.mainnet.x1.xyz/snapshot.tar.bz2
 )
 
 snapshot=$(ls "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot/snapshot-[0-9]*-*.tar.zst)

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "2.2.18"
+version = "2.2.19"
 description = "Solana SBF test program written in Rust"
 authors = ["X1 Labs maintainers <maintainers@x1.xyz>"]
 repository = "https://github.com/x1-labs/tachyon"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "2.2.18"
+version = "2.2.19"
 description = "Solana SBF test program written in Rust"
 authors = ["X1 Labs maintainers <maintainers@x1.xyz>"]
 repository = "https://github.com/x1-labs/tachyon"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package-metadata"
-version = "2.2.18"
+version = "2.2.19"
 description = "Solana SBF test program with tools version in package metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-metadata"
-version = "2.2.18"
+version = "2.2.19"
 description = "Solana SBF test program with tools version in workspace metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-clock",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -738,7 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5060,7 +5060,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5099,7 +5099,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5142,7 +5142,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "thiserror 2.0.11",
 ]
 
@@ -5157,14 +5157,14 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -5173,18 +5173,18 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bv",
  "fnv",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -5317,14 +5317,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "solana-address-lookup-table-program",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "chrono",
  "clap",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "chrono",
@@ -5629,12 +5629,12 @@ dependencies = [
  "solana-short-vec",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-clock",
@@ -5853,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "clap",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-v0"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6258,7 +6258,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6411,7 +6411,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6489,7 +6489,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6507,13 +6507,13 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
 ]
@@ -6533,11 +6533,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6600,7 +6600,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6682,7 +6682,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6743,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6956,14 +6956,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6991,7 +6991,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-program",
  "thiserror 2.0.11",
  "tokio",
@@ -7026,7 +7026,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -7097,7 +7097,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "console",
  "dialoguer",
@@ -7181,7 +7181,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7227,7 +7227,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7278,7 +7278,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7307,7 +7307,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7394,7 +7394,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7437,7 +7437,7 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sbf-programs"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7474,7 +7474,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-vote",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-128bit-dep",
@@ -7492,35 +7492,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-account-mem"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-account-mem-deprecated"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -7529,7 +7529,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -7538,7 +7538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-big-mod-exp"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "array-bytes",
  "serde",
@@ -7549,7 +7549,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-args"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "borsh 1.5.5",
  "solana-program",
@@ -7557,21 +7557,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-curve25519",
  "solana-program",
@@ -7579,14 +7579,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "byteorder 1.5.0",
  "solana-program",
@@ -7594,28 +7594,28 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-divide-by-zero"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -7626,35 +7626,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoke-dep",
@@ -7664,32 +7664,32 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-dep"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoked-dep",
@@ -7697,28 +7697,28 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoked-dep"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-many-args-dep",
@@ -7726,14 +7726,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem-dep",
@@ -7741,14 +7741,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem-dep"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem-dep",
@@ -7756,21 +7756,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-param-passing-dep",
@@ -7778,14 +7778,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "array-bytes",
  "solana-poseidon",
@@ -7794,7 +7794,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -7803,7 +7803,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc-dep",
@@ -7811,14 +7811,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-dep"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc-dep",
@@ -7827,39 +7827,39 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke-dep"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "libsecp256k1 0.7.0",
  "solana-program",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "blake3",
  "solana-program",
@@ -7876,42 +7876,42 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-inner-instructions"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "solana-program",
@@ -7919,21 +7919,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-syscall-get-epoch-stake"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-program",
 ]
@@ -8119,7 +8119,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8299,14 +8299,14 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -8346,7 +8346,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "bs58",
@@ -8361,7 +8361,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-channel",
  "bytes",
@@ -8414,7 +8414,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -8452,7 +8452,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-type-overrides",
  "thiserror 2.0.11",
@@ -8460,15 +8460,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "log",
@@ -8514,7 +8514,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
 ]
 
@@ -8582,7 +8582,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "log",
@@ -8646,7 +8646,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8655,7 +8655,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "rustls 0.23.22",
  "solana-keypair",
@@ -8666,7 +8666,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8741,7 +8741,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "serde",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8822,7 +8822,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8836,14 +8836,14 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8883,7 +8883,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8891,7 +8891,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8905,7 +8905,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8916,7 +8916,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8951,7 +8951,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "semver",
@@ -8963,7 +8963,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -9010,7 +9010,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9035,14 +9035,14 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-interface",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "log",
@@ -9067,7 +9067,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9082,7 +9082,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9132,7 +9132,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9709,7 +9709,7 @@ dependencies = [
 
 [[package]]
 name = "tachyon-validator"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-geyser-plugin-interface",
  "chrono",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -73,7 +73,7 @@ members = [
     "rust/upgraded",
 ]
 [workspace.package]
-version = "2.2.18"
+version = "2.2.19"
 description = "Solana SBF test program written in Rust"
 authors = ["X1 Labs maintainers <maintainers@x1.xyz>"]
 repository = "https://github.com/x1-labs/tachyon"
@@ -89,8 +89,8 @@ check-cfg = [
 ]
 
 [workspace.dependencies]
-agave-feature-set = { path = "../../feature-set", version = "=2.2.18" }
-agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.2.18" }
+agave-feature-set = { path = "../../feature-set", version = "=2.2.19" }
+agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.2.19" }
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
@@ -109,45 +109,45 @@ rand = "0.8"
 serde = "1.0.112"                                                                             # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_derive = "1.0.112"                                                                      # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.56"
-solana-account-decoder = { path = "../../account-decoder", version = "=2.2.18" }
-solana-accounts-db = { path = "../../accounts-db", version = "=2.2.18" }
+solana-account-decoder = { path = "../../account-decoder", version = "=2.2.19" }
+solana-accounts-db = { path = "../../accounts-db", version = "=2.2.19" }
 solana-bn254 = "=2.2.2"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.2.18" }
-solana-cli-output = { path = "../../cli-output", version = "=2.2.18" }
-solana-compute-budget = { path = "../../compute-budget", version = "=2.2.18" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.2.18" }
-solana-curve25519 = { path = "../../curves/curve25519", version = "=2.2.18" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.2.19" }
+solana-cli-output = { path = "../../cli-output", version = "=2.2.19" }
+solana-compute-budget = { path = "../../compute-budget", version = "=2.2.19" }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.2.19" }
+solana-curve25519 = { path = "../../curves/curve25519", version = "=2.2.19" }
 solana-decode-error = "=2.2.1"
-solana-fee = { path = "../../fee", version = "=2.2.18" }
-solana-ledger = { path = "../../ledger", version = "=2.2.18" }
-solana-log-collector = { path = "../../log-collector", version = "=2.2.18" }
+solana-fee = { path = "../../fee", version = "=2.2.19" }
+solana-ledger = { path = "../../ledger", version = "=2.2.19" }
+solana-log-collector = { path = "../../log-collector", version = "=2.2.19" }
 solana-logger = "=2.3.1"
-solana-measure = { path = "../../measure", version = "=2.2.18" }
-solana-poseidon = { path = "../../poseidon/", version = "=2.2.18" }
+solana-measure = { path = "../../measure", version = "=2.2.19" }
+solana-poseidon = { path = "../../poseidon/", version = "=2.2.19" }
 solana-program = "=2.2.1"
-solana-program-runtime = { path = "../../program-runtime", version = "=2.2.18" }
-solana-runtime = { path = "../../runtime", version = "=2.2.18" }
-solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.2.18" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.2.18" }
-solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.2.18" }
-solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.2.18" }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.2.18" }
-solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.2.18" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.2.18" }
-solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.18" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.18" }
+solana-program-runtime = { path = "../../program-runtime", version = "=2.2.19" }
+solana-runtime = { path = "../../runtime", version = "=2.2.19" }
+solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.2.19" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.2.19" }
+solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.2.19" }
+solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.2.19" }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.2.19" }
+solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.2.19" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.2.19" }
+solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.19" }
+solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.19" }
 solana-sbpf = "=0.10.1"
 solana-sdk = "=2.2.2"
 solana-secp256k1-recover = "=2.2.1"
-solana-svm = { path = "../../svm", version = "=2.2.18" }
-solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.18" }
-solana-timings = { path = "../../timings", version = "=2.2.18" }
-solana-transaction-context = { path = "../../transaction-context", version = "=2.2.18" }
-solana-transaction-status = { path = "../../transaction-status", version = "=2.2.18" }
-solana-type-overrides = { path = "../../type-overrides", version = "=2.2.18" }
-solana-vote = { path = "../../vote", version = "=2.2.18" }
-solana-vote-program = { path = "../../programs/vote", version = "=2.2.18" }
-tachyon-validator = { path = "../../validator", version = "=2.2.18" }
+solana-svm = { path = "../../svm", version = "=2.2.19" }
+solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.19" }
+solana-timings = { path = "../../timings", version = "=2.2.19" }
+solana-transaction-context = { path = "../../transaction-context", version = "=2.2.19" }
+solana-transaction-status = { path = "../../transaction-status", version = "=2.2.19" }
+solana-type-overrides = { path = "../../type-overrides", version = "=2.2.19" }
+solana-vote = { path = "../../vote", version = "=2.2.19" }
+solana-vote-program = { path = "../../programs/vote", version = "=2.2.19" }
+tachyon-validator = { path = "../../validator", version = "=2.2.19" }
 solana-zk-sdk = "=2.2.1"
 thiserror = "1.0"
 

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -129,7 +129,7 @@ for Cargo_toml in "${Cargo_tomls[@]}"; do
   # Set new crate version
   (
     set -x
-    sed -i "$Cargo_toml" -e "0,/^version =/{s/^version = \"[^\"]*\"$/version = \"$newVersion\"/}"
+    sed -i "$Cargo_toml" -e "s/^version = \"$currentVersion\"$/version = \"$newVersion\"/"
   )
 
   # Fix up the version references to other internal crates

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "solana-clock",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -723,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "borsh 1.5.5",
  "clap",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-server"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -2723,7 +2723,7 @@ dependencies = [
  "solana-sdk",
  "solana-svm",
  "solana-system-program",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-version",
  "spl-token-2022 7.0.0",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5031,7 +5031,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5074,7 +5074,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "thiserror 2.0.11",
 ]
 
@@ -5089,14 +5089,14 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -5105,18 +5105,18 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bv",
  "fnv",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -5249,14 +5249,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "solana-address-lookup-table-program",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "chrono",
  "clap",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "chrono",
@@ -5561,12 +5561,12 @@ dependencies = [
  "solana-short-vec",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "clap",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-v0"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6156,7 +6156,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6309,7 +6309,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6405,13 +6405,13 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "log",
 ]
@@ -6431,11 +6431,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.18"
+version = "2.2.19"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6498,7 +6498,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6610,7 +6610,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6854,14 +6854,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6889,7 +6889,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-program",
  "thiserror 2.0.11",
  "tokio",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6949,7 +6949,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6987,7 +6987,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "console",
  "dialoguer",
@@ -7079,7 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7125,7 +7125,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7176,7 +7176,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7205,7 +7205,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7291,7 +7291,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7309,7 +7309,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7513,7 +7513,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -7673,7 +7673,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7693,14 +7693,14 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "bs58",
@@ -7755,7 +7755,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -7763,7 +7763,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-channel",
  "bytes",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7845,7 +7845,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "solana-type-overrides",
  "thiserror 2.0.11",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-example-paytube"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7872,15 +7872,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -7908,7 +7908,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "log",
@@ -7926,7 +7926,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-type-overrides",
 ]
 
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -8025,7 +8025,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "log",
@@ -8058,7 +8058,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8067,7 +8067,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "rustls 0.23.22",
  "solana-keypair",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "bincode",
  "serde",
@@ -8179,7 +8179,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8234,7 +8234,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8248,14 +8248,14 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8295,7 +8295,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8303,7 +8303,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8317,7 +8317,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8363,7 +8363,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "semver",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -8422,7 +8422,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8446,14 +8446,14 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context 2.2.19",
  "solana-vote-interface",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "anyhow",
  "log",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8493,7 +8493,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8543,7 +8543,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.18"
+version = "2.2.19"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -4,7 +4,7 @@ members = ["json-rpc/client", "json-rpc/server", "paytube"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.18"
+version = "2.2.19"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"

--- a/svm/examples/json-rpc/program/Cargo.toml
+++ b/svm/examples/json-rpc/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-rpc-example-program"
-version = "2.2.18"
+version = "2.2.19"
 edition = "2021"
 
 [features]

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-sysvar-program"
-version = "2.2.18"
+version = "2.2.19"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-solana-program"
-version = "2.2.18"
+version = "2.2.19"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-transfer-program"
-version = "2.2.18"
+version = "2.2.19"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-from-account"
-version = "2.2.18"
+version = "2.2.19"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-to-account"
-version = "2.2.18"
+version = "2.2.19"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Add new v2 migration feature gates for config, ALT, and feature gate programs to retry failed core BPF migrations on X1 mainnet
- Add `CORE_BPF_MIGRATION.md` with full deployment guide, verified ELF hashes, and version mapping table

The original migration features for config, ALT, and feature gate were activated on X1 mainnet but failed silently because source buffer accounts were never deployed. Since the migration only triggers on *new* feature activation, new v2 feature gates and buffer addresses are required to retry.

**New feature gates:**
| Program | Feature ID |
|---------|-----------|
| Config v2 | `3W77RxrUfZpDDfPxgRHQG6ZBi2oLq7vdTctkAoJdozjL` |
| ALT v2 | `CjmzUVD3Z2jWobu5i8aeJ1MGc8gUVGeHXva5T86EaC6A` |
| Feature Gate v2 | `5r43RFT6ZsRJS3DpbWCJxEmDnsThJzbfuseTDKpiLrYi` |

Stake uses its existing feature gate (`8v4oWsx9gG9rXREnejzNYyjpYF5oTP1igE7pqLDt9bKe`) since it hasn't been activated yet.

**This release is safe to deploy with no behavior change.** The native builtins continue to run as before until the new features are activated. Completing these migrations is a prerequisite for upgrading to v2.3 or v3.0.

## Test plan

- [x] `cargo check -p agave-feature-set -p solana-builtins` compiles clean
- [x] `cargo test -p solana-runtime test_core_bpf_migration` compiles clean
- [ ] Deploy to testnet validators and verify no consensus issues
- [ ] Deploy buffer accounts and activate features one at a time on testnet
- [ ] Verify each program owner changes to `BPFLoaderUpgradeab1e` after epoch boundary
- [ ] Repeat on mainnet per CORE_BPF_MIGRATION.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)