### PR TITLE
Add temp feature gate to activate SBPFv2 on testnet

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1072,6 +1072,10 @@ pub mod enable_native_mint_wrap_account {
     solana_pubkey::declare_id!("BeCY6VL4CKQR2QUwe9w3iRtNMN91FMW1sXbRzwfc3WYc");
 }
 
+pub mod activate_sbpf_v2_on_testnet {
+    solana_pubkey::declare_id!("2nfJKYUWnUWwMZagconKyfE8fVjfmZ4SKmNbsBV4ajwE");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1307,6 +1311,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
         (enable_dynamic_fees_fixes_v1::id(), "Enable dynamic fees fixes v1"),
         (enable_native_mint_wrap_account::id(), "enable the native mint wrap account"),
+        (activate_sbpf_v2_on_testnet::id(), "temporary: activate SBPFv2 feature gate on testnet"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6569,6 +6569,39 @@ impl Bank {
             }
         }
 
+        // Temporary: when activate_sbpf_v2_on_testnet is activated, create the Feature
+        // account at enable_sbpf_v2_deployment_and_execution's address to force-activate it.
+        if new_feature_activations
+            .contains(&feature_set::activate_sbpf_v2_on_testnet::id())
+        {
+            let feature_id = feature_set::enable_sbpf_v2_deployment_and_execution::id();
+            // Feature account: 9 bytes, owner = Feature111...111
+            // Layout: 1 byte bool (1 = has slot) + 8 byte LE u64 (activation slot)
+            let mut data = vec![0u8; 9];
+            data[0] = 1; // activated = true
+            let slot_bytes = self.slot().to_le_bytes();
+            data[1..9].copy_from_slice(&slot_bytes);
+            let feature_program_id =
+                solana_pubkey::Pubkey::from_str_const("Feature111111111111111111111111111111111111");
+            self.store_account_and_update_capitalization(
+                &feature_id,
+                &solana_sdk::account::AccountSharedData::from(
+                    solana_sdk::account::Account {
+                        lamports: self.get_minimum_balance_for_rent_exemption(9),
+                        data,
+                        owner: feature_program_id,
+                        executable: false,
+                        rent_epoch: u64::MAX,
+                    },
+                ),
+            );
+            info!(
+                "Activated SBPFv2 feature gate {} at slot {}",
+                feature_id,
+                self.slot()
+            );
+        }
+
         if new_feature_activations.contains(&feature_set::enable_native_mint_wrap_account::id()) {
             self.store_account_and_update_capitalization(
                 &token::native_mint::id(),


### PR DESCRIPTION
## Summary
- The SBPFv2 feature (`F6UVKh1ujTEFK3en2SyAL3cdVnqko1FVEXWhmdLRu6WP`) was activated at genesis on mainnet but is missing on testnet
- Since the original keypair is unavailable, this adds a proxy feature gate (`2nfJKYUWnUWwMZagconKyfE8fVjfmZ4SKmNbsBV4ajwE`) that when activated, creates the Feature account at the SBPFv2 address to force-activate it
- This change should be reverted after activation on testnet

## Test plan
- [ ] Build release binary with this change
- [ ] Deploy to testnet validators
- [ ] Activate: `solana feature activate 2nfJKYUWnUWwMZagconKyfE8fVjfmZ4SKmNbsBV4ajwE <keypair> --url https://rpc.testnet.x1.xyz`
- [ ] Verify SBPFv2 feature account exists on testnet
- [ ] Revert this change and redeploy normal binary