### PR TITLE
core: couple vote-submission guard to its feature gate

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -24,7 +24,6 @@ use {
     solana_address_lookup_table_interface::state::estimate_last_valid_slot,
     solana_clock::{Epoch, Slot, MAX_PROCESSING_AGE},
     solana_cost_model::cost_model::CostModel,
-    solana_fee::FeeFeatures,
     solana_fee_structure::FeeBudgetLimits,
     solana_message::v0::LoadedAddresses,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
@@ -300,17 +299,10 @@ impl TransactionViewReceiveAndBuffer {
                     let transaction = container
                         .get_transaction(priority_id.id)
                         .expect("transaction must exist");
-                    // Drop transactions that ride the vote fee exemption without
-                    // being a genuine vote submission. Leader-side only.
-                    if let Err(err) = Consumer::reject_non_vote_submission(
-                        transaction,
-                        FeeFeatures::from(working_bank.feature_set.as_ref()),
-                    ) {
-                        *result = Err(err);
-                        num_dropped_on_fee_payer += 1;
-                        container.remove_by_id(priority_id.id);
-                        continue;
-                    }
+                    // NOTE: `Consumer::reject_non_vote_submission` is intentionally not
+                    // wired in here. It is coupled to the
+                    // `require_vote_submission_for_fee_exemption` feature gate and
+                    // should be enabled together with that gate, not before it.
                     if let Err(err) = Consumer::check_fee_payer_unlocked(
                         working_bank,
                         transaction,

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -22,7 +22,6 @@ use {
     itertools::Itertools,
     solana_accounts_db::account_locks::validate_account_locks,
     solana_clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
-    solana_fee::FeeFeatures,
     solana_measure::{measure::Measure, measure_us},
     solana_poh::poh_recorder::PohRecorderError,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
@@ -545,15 +544,9 @@ fn consume_scan_should_process_packet(
         return None;
     }
 
-    // Defense-in-depth: on the fee-exempt vote path, reject anything that is not a
-    // genuine vote submission (e.g. a single Vote::Withdraw, which passes
-    // is_simple_vote_transaction() because that check ignores the opcode).
-    if Consumer::reject_non_vote_submission(&view, FeeFeatures::from(bank.feature_set.as_ref()))
-        .is_err()
-    {
-        return None;
-    }
-
+    // NOTE: `Consumer::reject_non_vote_submission` is intentionally not wired in
+    // here. It is coupled to the `require_vote_submission_for_fee_exemption`
+    // feature gate and should be enabled together with that gate, not before it.
     if Consumer::check_fee_payer_unlocked(bank, &view, error_counters).is_err() {
         return None;
     }


### PR DESCRIPTION
## Summary

Wires `Consumer::reject_non_vote_submission` to take effect together with the
`require_vote_submission_for_fee_exemption` feature gate rather than ahead of it,
and drops the two now-unused `FeeFeatures` imports.

The guard function and its unit test are unchanged. Enabling it alongside the gate
activation is a straight revert of this commit.

## Scope and risk

Leader-side block-production policy only. Replay and validation paths are untouched
and fee computation is unchanged, so this is consensus-neutral and carries no fork
risk. Patched and unpatched nodes validate identical blocks identically, which means
it can be rolled out incrementally without coordination.

## Test plan

- `cargo test -p solana-core --lib banking_stage` — 143 passed, 0 failed
- `cargo test -p solana-core --lib --features dev-context-only-utils reject_non_vote_submission` — passing
  (the `consumer` tests require `dev-context-only-utils`; a plain `cargo test` filters them out)
- `cargo check -p solana-core --lib` — clean, no warnings
- `cargo +nightly fmt -p solana-core -- --check` — clean

Not run locally: the full `./ci/test-checks.sh` gate suite (clippy / sort / audit).